### PR TITLE
Use "cookies" from 4.02.1 to make named regexps work in toplevel

### DIFF
--- a/opam
+++ b/opam
@@ -5,8 +5,11 @@ build: [
   [make "opt"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "sedlex"]]
-depends: ["ocamlfind" {>= "1.5.0"}
-          "ppx_tools" {>= "0.99"}
-         ]
-ocaml-version: [>= "4.02.0"]
+remove: [
+  ["ocamlfind" "remove" "sedlex"]
+]
+depends: [
+  "ocamlfind" {>= "1.5.0"}
+  "ppx_tools" {>= "0.99"}
+]
+ocaml-version: [>= "4.02.1"]


### PR DESCRIPTION
Test code (t.ml):

```
#require "sedlex";;

let lid = [%sedlex.regexp? "foo"];;

let lex lexbuf =
  match%sedlex lexbuf with
  | lid -> true
  | _ -> false
;;
```

```
ocaml <t.ml
```
