### PR TITLE
Embed chunk size in the lexbuf to allow interactive capture #45

### DIFF
--- a/src/lib/sedlexing.ml
+++ b/src/lib/sedlexing.ml
@@ -74,10 +74,10 @@ let empty_lexbuf = {
 
 let create ?(chunk_size=512) f = {
   empty_lexbuf with
-    refill = f;
-    chunk_size;
-    buf = Array.make chunk_size (Uchar.of_int 0);
-    curr_line = 1;
+  refill = f;
+  chunk_size;
+  buf = Array.make chunk_size (Uchar.of_int 0);
+  curr_line = 1;
 }
 
 let set_position lexbuf position =
@@ -107,20 +107,19 @@ let from_int_array a =
   let len = Array.length a in
   {
     empty_lexbuf with
-      buf = Array.init len (fun i -> Uchar.of_int a.(i));
-      len = len;
-      finished = true;
+    buf = Array.init len (fun i -> Uchar.of_int a.(i));
+    len = len;
+    finished = true;
   }
 
 let from_uchar_array a =
   let len = Array.length a in
   {
     empty_lexbuf with
-      buf = Array.init len (fun i -> a.(i));
-      len = len;
-      finished = true;
+    buf = Array.init len (fun i -> a.(i));
+    len = len;
+    finished = true;
   }
-
 
 let refill lexbuf =
   if lexbuf.len + lexbuf.chunk_size > Array.length lexbuf.buf
@@ -148,7 +147,7 @@ let refill lexbuf =
 
 let new_line lexbuf =
   if lexbuf.curr_line != 0 then
-  lexbuf.curr_line <- lexbuf.curr_line + 1;
+    lexbuf.curr_line <- lexbuf.curr_line + 1;
   lexbuf.curr_bol <- lexbuf.pos + lexbuf.offset
 
 let next lexbuf =
@@ -231,10 +230,10 @@ module Latin1 = struct
   let from_string s =
     let len = String.length s in
     {
-     empty_lexbuf with
-     buf = Array.init len (fun i -> Uchar.of_char s.[i]);
-     len = len;
-     finished = true;
+      empty_lexbuf with
+      buf = Array.init len (fun i -> Uchar.of_char s.[i]);
+      len = len;
+      finished = true;
     }
 
   let from_channel ?(chunk_size=512) ic =
@@ -272,69 +271,66 @@ module Utf8 = struct
     let next s i =
       match s.[i] with
       | '\000'..'\127' as c ->
-          Char.code c
+        Char.code c
       | '\192'..'\223' as c ->
-	  let n1 = Char.code c in
-	  let n2 = Char.code s.[i+1] in
-          if (n2 lsr 6 != 0b10) then raise MalFormed;
-          ((n1 land 0x1f) lsl 6) lor (n2 land 0x3f)
+        let n1 = Char.code c in
+        let n2 = Char.code s.[i+1] in
+        if (n2 lsr 6 != 0b10) then raise MalFormed;
+        ((n1 land 0x1f) lsl 6) lor (n2 land 0x3f)
       | '\224'..'\239' as c ->
-	  let n1 = Char.code c in
-	  let n2 = Char.code s.[i+1] in
-	  let n3 = Char.code s.[i+2] in
-          if (n2 lsr 6 != 0b10) || (n3 lsr 6 != 0b10) then raise MalFormed;
-	  let p =
-            ((n1 land 0x0f) lsl 12) lor ((n2 land 0x3f) lsl 6) lor (n3 land 0x3f)
-	  in
-	  if (p >= 0xd800) && (p <= 0xdf00) then raise MalFormed;
-	  p
+        let n1 = Char.code c in
+        let n2 = Char.code s.[i+1] in
+        let n3 = Char.code s.[i+2] in
+        if (n2 lsr 6 != 0b10) || (n3 lsr 6 != 0b10) then raise MalFormed;
+        let p =
+          ((n1 land 0x0f) lsl 12) lor ((n2 land 0x3f) lsl 6) lor (n3 land 0x3f)
+        in
+        if (p >= 0xd800) && (p <= 0xdf00) then raise MalFormed;
+        p
       | '\240'..'\247' as c ->
-	  let n1 = Char.code c in
-	  let n2 = Char.code s.[i+1] in
-	  let n3 = Char.code s.[i+2] in
-	  let n4 = Char.code s.[i+3] in
-          if (n2 lsr 6 != 0b10) || (n3 lsr 6 != 0b10) || (n4 lsr 6 != 0b10)
-	  then raise MalFormed;
-          ((n1 land 0x07) lsl 18) lor ((n2 land 0x3f) lsl 12) lor
-          ((n3 land 0x3f) lsl 6) lor (n4 land 0x3f)
+        let n1 = Char.code c in
+        let n2 = Char.code s.[i+1] in
+        let n3 = Char.code s.[i+2] in
+        let n4 = Char.code s.[i+3] in
+        if (n2 lsr 6 != 0b10) || (n3 lsr 6 != 0b10) || (n4 lsr 6 != 0b10)
+        then raise MalFormed;
+        ((n1 land 0x07) lsl 18) lor ((n2 land 0x3f) lsl 12) lor
+        ((n3 land 0x3f) lsl 6) lor (n4 land 0x3f)
       | _ -> raise MalFormed
-
 
     let from_gen s =
       Gen.next s >>= function
       | '\000'..'\127' as c ->
-          Some (Uchar.of_char c)
+        Some (Uchar.of_char c)
       | '\192'..'\223' as c ->
-	  let n1 = Char.code c in
-	  Gen.next s >>= fun c2 ->
-	  let n2 = Char.code c2 in
-          if (n2 lsr 6 != 0b10) then raise MalFormed;
-          Some (Uchar.of_int (((n1 land 0x1f) lsl 6) lor (n2 land 0x3f)))
+        let n1 = Char.code c in
+        Gen.next s >>= fun c2 ->
+        let n2 = Char.code c2 in
+        if (n2 lsr 6 != 0b10) then raise MalFormed;
+        Some (Uchar.of_int (((n1 land 0x1f) lsl 6) lor (n2 land 0x3f)))
       | '\224'..'\239' as c ->
-	  let n1 = Char.code c in
-	  Gen.next s >>= fun c2 ->
-	  let n2 = Char.code c2 in
-	  Gen.next s >>= fun c3 ->
-	  let n3 = Char.code c3 in
-          if (n2 lsr 6 != 0b10) || (n3 lsr 6 != 0b10) then raise MalFormed;
-          Some (Uchar.of_int (((n1 land 0x0f) lsl 12)
-                              lor ((n2 land 0x3f) lsl 6) lor (n3 land 0x3f)))
+        let n1 = Char.code c in
+        Gen.next s >>= fun c2 ->
+        let n2 = Char.code c2 in
+        Gen.next s >>= fun c3 ->
+        let n3 = Char.code c3 in
+        if (n2 lsr 6 != 0b10) || (n3 lsr 6 != 0b10) then raise MalFormed;
+        Some (Uchar.of_int (((n1 land 0x0f) lsl 12)
+                            lor ((n2 land 0x3f) lsl 6) lor (n3 land 0x3f)))
       | '\240'..'\247' as c ->
-	  let n1 = Char.code c in
-	  Gen.next s >>= fun c2 ->
-	  let n2 = Char.code c2 in
-	  Gen.next s >>= fun c3 ->
-	  let n3 = Char.code c3 in
-	  Gen.next s >>= fun c4 ->
-	  let n4 = Char.code c4 in
-          if (n2 lsr 6 != 0b10) || (n3 lsr 6 != 0b10) || (n4 lsr 6 != 0b10)
-	  then raise MalFormed;
-          Some (Uchar.of_int (((n1 land 0x07) lsl 18)
-                              lor ((n2 land 0x3f) lsl 12)
-                              lor ((n3 land 0x3f) lsl 6) lor (n4 land 0x3f)))
+        let n1 = Char.code c in
+        Gen.next s >>= fun c2 ->
+        let n2 = Char.code c2 in
+        Gen.next s >>= fun c3 ->
+        let n3 = Char.code c3 in
+        Gen.next s >>= fun c4 ->
+        let n4 = Char.code c4 in
+        if (n2 lsr 6 != 0b10) || (n3 lsr 6 != 0b10) || (n4 lsr 6 != 0b10)
+        then raise MalFormed;
+        Some (Uchar.of_int (((n1 land 0x07) lsl 18)
+                            lor ((n2 land 0x3f) lsl 12)
+                            lor ((n3 land 0x3f) lsl 6) lor (n4 land 0x3f)))
       | _ -> raise MalFormed
-
-
 
     let compute_len s pos bytes =
       let rec aux n i =
@@ -358,27 +354,25 @@ module Utf8 = struct
       blit_to_int s pos a 0 n;
       a
 
-(**************************)
-
     let store b p =
       if p <= 0x7f then
         Buffer.add_char b (Char.chr p)
       else if p <= 0x7ff then (
         Buffer.add_char b (Char.chr (0xc0 lor (p lsr 6)));
         Buffer.add_char b (Char.chr (0x80 lor (p land 0x3f)))
-       )
+      )
       else if p <= 0xffff then (
         if (p >= 0xd800 && p < 0xe000) then raise MalFormed;
         Buffer.add_char b (Char.chr (0xe0 lor (p lsr 12)));
         Buffer.add_char b (Char.chr (0x80 lor ((p lsr 6) land 0x3f)));
         Buffer.add_char b (Char.chr (0x80 lor (p land 0x3f)))
-       )
+      )
       else if p <= 0x10ffff then (
         Buffer.add_char b (Char.chr (0xf0 lor (p lsr 18)));
         Buffer.add_char b (Char.chr (0x80 lor ((p lsr 12) land 0x3f)));
         Buffer.add_char b (Char.chr (0x80 lor ((p lsr 6)  land 0x3f)));
         Buffer.add_char b (Char.chr (0x80 lor (p land 0x3f)))
-       )
+      )
       else raise MalFormed
 
     let from_uchar_array a apos len =
@@ -397,7 +391,7 @@ module Utf8 = struct
 
   let from_gen ?(chunk_size=512) s =
     create ~chunk_size (fill_buf_from_gen (fun id -> id)
-        (Helper.gen_from_char_gen s))
+                          (Helper.gen_from_char_gen s))
 
   let from_stream ?(chunk_size=512) s =
     from_gen ~chunk_size @@ gen_of_stream s
@@ -419,13 +413,13 @@ module Utf16 = struct
     (* http://www.ietf.org/rfc/rfc2781.txt *)
 
     let number_of_char_pair bo c1 c2 = match bo with
-    | Little_endian -> ((Char.code c2) lsl 8) + (Char.code c1)
-    | Big_endian -> ((Char.code c1) lsl 8) + (Char.code c2)
+      | Little_endian -> ((Char.code c2) lsl 8) + (Char.code c1)
+      | Big_endian -> ((Char.code c1) lsl 8) + (Char.code c2)
 
     let char_pair_of_number bo num = match bo with
-    | Little_endian ->
+      | Little_endian ->
         (Char.chr (num land 0xFF), Char.chr ((num lsr 8) land 0xFF ))
-    | Big_endian ->
+      | Big_endian ->
         (Char.chr ((num lsr 8) land 0xFF), Char.chr (num land 0xFF))
 
     let next_in_gen bo s =
@@ -453,13 +447,12 @@ module Utf16 = struct
         let o = match !bo with
           | Some o -> o
           | None ->
-              let o = match (Char.code c1, Char.code c2) with
-                | (0xff,0xfe) -> Little_endian
-                | _ -> Big_endian in
-              bo := Some o;
-              o in
+            let o = match (Char.code c1, Char.code c2) with
+              | (0xff,0xfe) -> Little_endian
+              | _ -> Big_endian in
+            bo := Some o;
+            o in
         from_gen o s (number_of_char_pair o c1 c2)
-
 
     let compute_len opt_bo str pos bytes =
       let s = gen_from_char_gen opt_bo
@@ -480,7 +473,7 @@ module Utf16 = struct
       let len = compute_len opt_bo s pos bytes in
       let a = Array.make len (Uchar.of_int 0) in
       blit_to_int opt_bo s pos a 0 bytes ;
-       a
+      a
 
     let store bo buf code =
       if code < 0x10000
@@ -488,7 +481,7 @@ module Utf16 = struct
         let (c1,c2) = char_pair_of_number bo code in
         Buffer.add_char buf c1;
         Buffer.add_char buf c2
-       ) else (
+      ) else (
         let u' = code - 0x10000  in
         let w1 = 0xd800 + (u' lsr 10)
         and w2 = 0xdc00 + (u' land 0x3ff) in
@@ -498,7 +491,7 @@ module Utf16 = struct
         Buffer.add_char buf c2;
         Buffer.add_char buf c3;
         Buffer.add_char buf c4
-       )
+      )
 
     let from_uchar_array bo a apos len bom =
       let b = Buffer.create (len * 4 + 2) in (* +2 for the BOM *)
@@ -508,8 +501,7 @@ module Utf16 = struct
         then (store bo b (Uchar.to_int a.(apos)); aux (succ apos) (pred len))
         else Buffer.contents b  in
       aux apos len
-end
-
+  end
 
   let from_gen ?(chunk_size=512) s opt_bo =
     from_gen ~chunk_size (Helper.gen_from_char_gen opt_bo s)

--- a/src/lib/sedlexing.mli
+++ b/src/lib/sedlexing.mli
@@ -23,53 +23,53 @@
     be used in the lexers semantic actions.  *)
 
 type lexbuf
-      (** The type of lexer buffers. A lexer buffer is the argument passed
-          to the scanning functions defined by the generated lexers.
-          The lexer buffer holds the internal information for the
-          scanners, including the code points of the token currently scanned,
-          its position from the beginning of the input stream,
-          and the current position of the lexer. *)
+(** The type of lexer buffers. A lexer buffer is the argument passed
+    to the scanning functions defined by the generated lexers.
+    The lexer buffer holds the internal information for the
+    scanners, including the code points of the token currently scanned,
+    its position from the beginning of the input stream,
+    and the current position of the lexer. *)
 
 exception InvalidCodepoint of int
-    (** Raised by some functions to signal that some code point is not
-        compatible with a specified encoding. *)
+(** Raised by some functions to signal that some code point is not
+    compatible with a specified encoding. *)
 
 exception MalFormed
-    (** Raised by functions in the [Utf8] and [Utf16] modules to report
-        strings which do not comply to the encoding. *)
+(** Raised by functions in the [Utf8] and [Utf16] modules to report
+    strings which do not comply to the encoding. *)
 
 (** {6 Creating generic lexbufs} *)
 
 val create: ?chunk_size:int -> (Uchar.t array -> int -> int -> int) -> lexbuf
-    (** Create a generic lexer buffer.  When the lexer needs more
-        characters, it will call the given function, giving it an array of
-        Uchars [a], a position [pos] and a code point count [n].  The
-        function should put [n] code points or less in [a], starting at
-        position [pos], and return the number of characters provided. A
-        return value of 0 means end of input. *)
+(** Create a generic lexer buffer.  When the lexer needs more
+    characters, it will call the given function, giving it an array of
+    Uchars [a], a position [pos] and a code point count [n].  The
+    function should put [n] code points or less in [a], starting at
+    position [pos], and return the number of characters provided. A
+    return value of 0 means end of input. *)
 
 val set_position: lexbuf -> Lexing.position -> unit
-    (** set the initial tracked input position for [lexbuf].
-        If set to [Lexing.dummy_pos], Sedlexing will not track position
-        information for you. *)
+(** set the initial tracked input position for [lexbuf].
+    If set to [Lexing.dummy_pos], Sedlexing will not track position
+    information for you. *)
 
 val set_filename: lexbuf -> string -> unit
-    (** [set_filename lexbuf file] sets the filename to [file] in
-        [lexbuf]. It also sets the {!Lexing.pos_fname} field in
-        returned {!Lexing.position} records. *)
+(** [set_filename lexbuf file] sets the filename to [file] in
+    [lexbuf]. It also sets the {!Lexing.pos_fname} field in
+    returned {!Lexing.position} records. *)
 
 val from_gen: ?chunk_size:int -> Uchar.t Gen.t -> lexbuf
-    (** Create a lexbuf from a stream of Unicode code points. *)
+(** Create a lexbuf from a stream of Unicode code points. *)
 
 val from_stream: ?chunk_size:int -> Uchar.t Stream.t -> lexbuf
-    [@@ocaml.deprecated "Use [Sedlexing.from_gen] instead."]
-    (** Create a lexbuf from a stream of Unicode code points. *)
+[@@ocaml.deprecated "Use [Sedlexing.from_gen] instead."]
+(** Create a lexbuf from a stream of Unicode code points. *)
 
 val from_int_array: int array -> lexbuf
-    (** Create a lexbuf from an array of Unicode code points. *)
+(** Create a lexbuf from an array of Unicode code points. *)
 
 val from_uchar_array: Uchar.t array -> lexbuf
-    (** Create a lexbuf from an array of Unicode code points. *)
+(** Create a lexbuf from an array of Unicode code points. *)
 
 (** {6 Interface for lexers semantic actions} *)
 
@@ -78,45 +78,45 @@ val from_uchar_array: Uchar.t array -> lexbuf
     by the regular expression associated with the semantic action. *)
 
 val lexeme_start: lexbuf -> int
-    (** [Sedlexing.lexeme_start lexbuf] returns the offset in the
-        input stream of the first code point of the matched string.
-        The first code point of the stream has offset 0. *)
+(** [Sedlexing.lexeme_start lexbuf] returns the offset in the
+    input stream of the first code point of the matched string.
+    The first code point of the stream has offset 0. *)
 
 val lexeme_end: lexbuf -> int
-    (** [Sedlexing.lexeme_end lexbuf] returns the offset in the input
-        stream of the character following the last code point of the
-        matched string. The first character of the stream has offset
-        0. *)
+(** [Sedlexing.lexeme_end lexbuf] returns the offset in the input
+    stream of the character following the last code point of the
+    matched string. The first character of the stream has offset
+    0. *)
 
 val loc: lexbuf -> int * int
-    (** [Sedlexing.loc lexbuf] returns the pair
-        [(Sedlexing.lexeme_start lexbuf,Sedlexing.lexeme_end
-        lexbuf)]. *)
+(** [Sedlexing.loc lexbuf] returns the pair
+    [(Sedlexing.lexeme_start lexbuf,Sedlexing.lexeme_end
+    lexbuf)]. *)
 
 val lexeme_length: lexbuf -> int
-    (** [Sedlexing.loc lexbuf] returns the difference
-        [(Sedlexing.lexeme_end lexbuf) - (Sedlexing.lexeme_start
-        lexbuf)], that is, the length (in code points) of the matched
-        string. *)
+(** [Sedlexing.loc lexbuf] returns the difference
+    [(Sedlexing.lexeme_end lexbuf) - (Sedlexing.lexeme_start
+    lexbuf)], that is, the length (in code points) of the matched
+    string. *)
 
 val lexing_positions : lexbuf -> Lexing.position*Lexing.position
-    (** [Sedlexing.lexing_positions lexbuf] returns the start and end
-        positions of the current token, using a record of type
-        [Lexing.position]. This is intended for consumption
-        by parsers like those generated by [Menhir]. *)
+(** [Sedlexing.lexing_positions lexbuf] returns the start and end
+    positions of the current token, using a record of type
+    [Lexing.position]. This is intended for consumption
+    by parsers like those generated by [Menhir]. *)
 
 val new_line: lexbuf -> unit
-    (** [Sedlexing.new_line lexbuf] increments the line count and
-        sets the beginning of line to the current position, as though
-        a newline character had been encountered in the input. *)
+(** [Sedlexing.new_line lexbuf] increments the line count and
+    sets the beginning of line to the current position, as though
+    a newline character had been encountered in the input. *)
 
 val lexeme: lexbuf -> Uchar.t array
-    (** [Sedlexing.lexeme lexbuf] returns the string matched by the
-        regular expression as an array of Unicode code point. *)
+(** [Sedlexing.lexeme lexbuf] returns the string matched by the
+    regular expression as an array of Unicode code point. *)
 
 val lexeme_char: lexbuf -> int -> Uchar.t
-    (** [Sedlexing.lexeme_char lexbuf pos] returns code point number [pos] in
-        the matched string. *)
+(** [Sedlexing.lexeme_char lexbuf pos] returns code point number [pos] in
+    the matched string. *)
 
 val sub_lexeme: lexbuf -> int -> int -> Uchar.t array
 (** [Sedlexing.sub_lexeme lexbuf pos len] returns a substring of the string
@@ -135,7 +135,7 @@ val rollback: lexbuf -> unit
     to write lexers by hand, or with a lexer generator different from
     [sedlex]. The lexer buffers have a unique internal slot that can store
     an integer. They also store a "backtrack" position.
- *)
+*)
 
 val start: lexbuf -> unit
 (** [start t] informs the lexer buffer that any
@@ -143,7 +143,7 @@ val start: lexbuf -> unit
     The current position become the "start" position as returned
     by [Sedlexing.lexeme_start]. Moreover, the internal slot is set to
     [-1] and the backtrack position is set to the current position.
- *)
+*)
 
 val next: lexbuf -> Uchar.t option
 (** [next lexbuf] extracts the next code point from the
@@ -170,58 +170,58 @@ val with_tokenizer: (lexbuf -> 'token) -> lexbuf -> (unit -> 'token * Lexing.pos
 
 module Latin1: sig
   val from_gen: ?chunk_size:int -> char Gen.t -> lexbuf
-      (** Create a lexbuf from a Latin1 encoded stream (ie a stream
-          of Unicode code points in the range [0..255]) *)
+  (** Create a lexbuf from a Latin1 encoded stream (ie a stream
+      of Unicode code points in the range [0..255]) *)
 
   val from_stream: ?chunk_size:int -> char Stream.t -> lexbuf
-      [@@ocaml.deprecated "Use [Sedlexing.Latin1.from_gen] instead."]
-      (** Create a lexbuf from a Latin1 encoded stream (ie a stream
-          of Unicode code points in the range [0..255]) *)
+  [@@ocaml.deprecated "Use [Sedlexing.Latin1.from_gen] instead."]
+  (** Create a lexbuf from a Latin1 encoded stream (ie a stream
+      of Unicode code points in the range [0..255]) *)
 
   val from_channel: ?chunk_size:int -> in_channel -> lexbuf
-      (** Create a lexbuf from a Latin1 encoded input channel.
-          The client is responsible for closing the channel. *)
+  (** Create a lexbuf from a Latin1 encoded input channel.
+      The client is responsible for closing the channel. *)
 
   val from_string: string -> lexbuf
-      (** Create a lexbuf from a Latin1 encoded string. *)
+  (** Create a lexbuf from a Latin1 encoded string. *)
 
 
   val lexeme: lexbuf -> string
-      (** As [Sedlexing.lexeme] with a result encoded in Latin1.  This
-          function throws an exception [InvalidCodepoint] if it is not
-          possible to encode the result in Latin1. *)
+  (** As [Sedlexing.lexeme] with a result encoded in Latin1.  This
+      function throws an exception [InvalidCodepoint] if it is not
+      possible to encode the result in Latin1. *)
 
   val sub_lexeme: lexbuf -> int -> int -> string
-      (** As [Sedlexing.sub_lexeme] with a result encoded in Latin1.
-          This function throws an exception [InvalidCodepoint] if it
-          is not possible to encode the result in Latin1. *)
+  (** As [Sedlexing.sub_lexeme] with a result encoded in Latin1.
+      This function throws an exception [InvalidCodepoint] if it
+      is not possible to encode the result in Latin1. *)
 
   val lexeme_char: lexbuf -> int -> char
-      (** As [Sedlexing.lexeme_char] with a result encoded in Latin1.
-          This function throws an exception [InvalidCodepoint] if it
-          is not possible to encode the result in Latin1. *)
+  (** As [Sedlexing.lexeme_char] with a result encoded in Latin1.
+      This function throws an exception [InvalidCodepoint] if it
+      is not possible to encode the result in Latin1. *)
 end
 
 
 module Utf8: sig
   val from_gen: ?chunk_size:int -> char Gen.t -> lexbuf
-      (** Create a lexbuf from a UTF-8 encoded stream. *)
+  (** Create a lexbuf from a UTF-8 encoded stream. *)
 
   val from_stream: ?chunk_size:int -> char Stream.t -> lexbuf
-      [@@ocaml.deprecated "Use [Sedlexing.Utf8.from_gen] instead."]
-      (** Create a lexbuf from a UTF-8 encoded stream. *)
+  [@@ocaml.deprecated "Use [Sedlexing.Utf8.from_gen] instead."]
+  (** Create a lexbuf from a UTF-8 encoded stream. *)
 
   val from_channel: ?chunk_size:int -> in_channel -> lexbuf
-      (** Create a lexbuf from a UTF-8 encoded input channel. *)
+  (** Create a lexbuf from a UTF-8 encoded input channel. *)
 
   val from_string: string -> lexbuf
-      (** Create a lexbuf from a UTF-8 encoded string. *)
+  (** Create a lexbuf from a UTF-8 encoded string. *)
 
   val lexeme: lexbuf -> string
-   (** As [Sedlexing.lexeme] with a result encoded in UTF-8. *)
+  (** As [Sedlexing.lexeme] with a result encoded in UTF-8. *)
 
   val sub_lexeme: lexbuf -> int -> int -> string
-      (** As [Sedlexing.sub_lexeme] with a result encoded in UTF-8. *)
+  (** As [Sedlexing.sub_lexeme] with a result encoded in UTF-8. *)
 end
 
 
@@ -229,32 +229,32 @@ module Utf16: sig
   type byte_order = Little_endian | Big_endian
 
   val from_gen: ?chunk_size:int -> char Gen.t -> byte_order option -> lexbuf
-      (** [Utf16.from_gen s opt_bo] creates a lexbuf from an UTF-16
-          encoded stream. If [opt_bo] matches with [None] the function
-          expects a BOM (Byte Order Mark), and takes the byte order as
-          [Utf16.Big_endian] if it cannot find one. When [opt_bo]
-          matches with [Some bo], [bo] is taken as byte order. In this
-          case a leading BOM is kept in the stream - the lexer has to
-          ignore it and a `wrong' BOM ([0xfffe]) will raise
-          Utf16.InvalidCodepoint.  *)
+  (** [Utf16.from_gen s opt_bo] creates a lexbuf from an UTF-16
+      encoded stream. If [opt_bo] matches with [None] the function
+      expects a BOM (Byte Order Mark), and takes the byte order as
+      [Utf16.Big_endian] if it cannot find one. When [opt_bo]
+      matches with [Some bo], [bo] is taken as byte order. In this
+      case a leading BOM is kept in the stream - the lexer has to
+      ignore it and a `wrong' BOM ([0xfffe]) will raise
+      Utf16.InvalidCodepoint.  *)
 
   val from_stream: ?chunk_size:int -> char Stream.t -> byte_order option -> lexbuf
-      [@@ocaml.deprecated "Use [Sedlexing.Utf16.from_gen] instead."]
-      (** Works as [Utf16.from_gen] with a [stream]. *)
+  [@@ocaml.deprecated "Use [Sedlexing.Utf16.from_gen] instead."]
+  (** Works as [Utf16.from_gen] with a [stream]. *)
 
   val from_channel: ?chunk_size:int -> in_channel -> byte_order option-> lexbuf
-      (** Works as [Utf16.from_gen] with an [in_channel]. *)
+  (** Works as [Utf16.from_gen] with an [in_channel]. *)
 
   val from_string: string -> byte_order option -> lexbuf
-      (** Works as [Utf16.from_gen] with a [string]. *)
+  (** Works as [Utf16.from_gen] with a [string]. *)
 
   val lexeme: lexbuf -> byte_order -> bool -> string
-      (** [utf16_lexeme lb bo bom] as [Sedlexing.lexeme] with a result
-          encoded in UTF-16 in byte_order [bo] and starting with a BOM
-          if [bom = true].  *)
+  (** [utf16_lexeme lb bo bom] as [Sedlexing.lexeme] with a result
+      encoded in UTF-16 in byte_order [bo] and starting with a BOM
+      if [bom = true].  *)
 
   val sub_lexeme: lexbuf -> int -> int -> byte_order -> bool -> string
-      (** [sub_lexeme lb pos len bo bom] as
-          [Sedlexing.sub_lexeme] with a result encoded in UTF-16 with
-          byte order [bo] and starting with a BOM if [bom=true] *)
+  (** [sub_lexeme lb pos len bo bom] as
+      [Sedlexing.sub_lexeme] with a result encoded in UTF-16 with
+      byte order [bo] and starting with a BOM if [bom=true] *)
 end

--- a/src/lib/sedlexing.mli
+++ b/src/lib/sedlexing.mli
@@ -40,7 +40,7 @@ exception MalFormed
 
 (** {6 Creating generic lexbufs} *)
 
-val create: (Uchar.t array -> int -> int -> int) -> lexbuf
+val create: ?chunk_size:int -> (Uchar.t array -> int -> int -> int) -> lexbuf
     (** Create a generic lexer buffer.  When the lexer needs more
         characters, it will call the given function, giving it an array of
         Uchars [a], a position [pos] and a code point count [n].  The
@@ -58,10 +58,10 @@ val set_filename: lexbuf -> string -> unit
         [lexbuf]. It also sets the {!Lexing.pos_fname} field in
         returned {!Lexing.position} records. *)
 
-val from_gen: Uchar.t Gen.t -> lexbuf
+val from_gen: ?chunk_size:int -> Uchar.t Gen.t -> lexbuf
     (** Create a lexbuf from a stream of Unicode code points. *)
 
-val from_stream: Uchar.t Stream.t -> lexbuf
+val from_stream: ?chunk_size:int -> Uchar.t Stream.t -> lexbuf
     [@@ocaml.deprecated "Use [Sedlexing.from_gen] instead."]
     (** Create a lexbuf from a stream of Unicode code points. *)
 
@@ -169,16 +169,16 @@ val with_tokenizer: (lexbuf -> 'token) -> lexbuf -> (unit -> 'token * Lexing.pos
 (** {6 Support for common encodings} *)
 
 module Latin1: sig
-  val from_gen: char Gen.t -> lexbuf
+  val from_gen: ?chunk_size:int -> char Gen.t -> lexbuf
       (** Create a lexbuf from a Latin1 encoded stream (ie a stream
           of Unicode code points in the range [0..255]) *)
 
-  val from_stream: char Stream.t -> lexbuf
+  val from_stream: ?chunk_size:int -> char Stream.t -> lexbuf
       [@@ocaml.deprecated "Use [Sedlexing.Latin1.from_gen] instead."]
       (** Create a lexbuf from a Latin1 encoded stream (ie a stream
           of Unicode code points in the range [0..255]) *)
 
-  val from_channel: in_channel -> lexbuf
+  val from_channel: ?chunk_size:int -> in_channel -> lexbuf
       (** Create a lexbuf from a Latin1 encoded input channel.
           The client is responsible for closing the channel. *)
 
@@ -204,14 +204,14 @@ end
 
 
 module Utf8: sig
-  val from_gen: char Gen.t -> lexbuf
+  val from_gen: ?chunk_size:int -> char Gen.t -> lexbuf
       (** Create a lexbuf from a UTF-8 encoded stream. *)
 
-  val from_stream: char Stream.t -> lexbuf
+  val from_stream: ?chunk_size:int -> char Stream.t -> lexbuf
       [@@ocaml.deprecated "Use [Sedlexing.Utf8.from_gen] instead."]
       (** Create a lexbuf from a UTF-8 encoded stream. *)
 
-  val from_channel: in_channel -> lexbuf
+  val from_channel: ?chunk_size:int -> in_channel -> lexbuf
       (** Create a lexbuf from a UTF-8 encoded input channel. *)
 
   val from_string: string -> lexbuf
@@ -228,7 +228,7 @@ end
 module Utf16: sig
   type byte_order = Little_endian | Big_endian
 
-  val from_gen: char Gen.t -> byte_order option -> lexbuf
+  val from_gen: ?chunk_size:int -> char Gen.t -> byte_order option -> lexbuf
       (** [Utf16.from_gen s opt_bo] creates a lexbuf from an UTF-16
           encoded stream. If [opt_bo] matches with [None] the function
           expects a BOM (Byte Order Mark), and takes the byte order as
@@ -238,11 +238,11 @@ module Utf16: sig
           ignore it and a `wrong' BOM ([0xfffe]) will raise
           Utf16.InvalidCodepoint.  *)
 
-  val from_stream: char Stream.t -> byte_order option -> lexbuf
+  val from_stream: ?chunk_size:int -> char Stream.t -> byte_order option -> lexbuf
       [@@ocaml.deprecated "Use [Sedlexing.Utf16.from_gen] instead."]
       (** Works as [Utf16.from_gen] with a [stream]. *)
 
-  val from_channel: in_channel -> byte_order option-> lexbuf
+  val from_channel: ?chunk_size:int -> in_channel -> byte_order option-> lexbuf
       (** Works as [Utf16.from_gen] with an [in_channel]. *)
 
   val from_string: string -> byte_order option -> lexbuf

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -27,11 +27,11 @@ let decision l =
   let l = List.map (fun (a, b, i) -> (a, b, Return i)) l in
   let rec merge2 = function
     | (a1, b1, d1) :: (a2, b2, d2) :: rest ->
-        let x =
-          if b1 + 1 = a2 then d2
-          else Lte (a2 - 1, Return (-1), d2)
-        in
-        (a1, b2, Lte (b1, d1, x)) :: merge2 rest
+      let x =
+        if b1 + 1 = a2 then d2
+        else Lte (a2 - 1, Return (-1), d2)
+      in
+      (a1, b2, Lte (b1, d1, x)) :: merge2 rest
     | rest -> rest
   in
   let rec aux = function
@@ -46,25 +46,25 @@ let limit = 8192
 let decision_table l =
   let rec aux m accu = function
     | ((a, b, i) as x)::rem when b < limit && i < 255->
-        aux (min a m) (x :: accu) rem
+      aux (min a m) (x :: accu) rem
     | rem -> m, accu, rem
   in
   let (min, table, rest) = aux max_int [] l in
   match table with
   | [] -> decision l
   | [(min, max, i)] ->
-      Lte (min - 1, Return (-1), (Lte (max, Return i, decision rest)))
+    Lte (min - 1, Return (-1), (Lte (max, Return i, decision rest)))
   | (_, max, _) :: _ ->
-      let arr = Array.make (max - min + 1) 0 in
-      let set (a, b, i) = for j = a to b do arr.(j - min) <- i + 1 done in
-      List.iter set table;
-      Lte (min - 1, Return (-1), Lte (max, Table (min, arr), decision rest))
+    let arr = Array.make (max - min + 1) 0 in
+    let set (a, b, i) = for j = a to b do arr.(j - min) <- i + 1 done in
+    List.iter set table;
+    Lte (min - 1, Return (-1), Lte (max, Table (min, arr), decision rest))
 
 let rec simplify min max = function
   | Lte (i,yes,no) ->
-      if i >= max then simplify min max yes
-      else if i < min then simplify min max no
-      else Lte (i, simplify min i yes, simplify (i+1) max no)
+    if i >= max then simplify min max yes
+    else if i < min then simplify min max no
+    else Lte (i, simplify min i yes, simplify (i+1) max no)
   | x -> x
 
 let segments_of_partition p =
@@ -86,73 +86,73 @@ let glb_value name def = Str.value Nonrecursive [Vb.mk (pvar name) def]
 (* Named regexps *)
 
 module StringMap = Map.Make(struct
-  type t = string
-  let compare = compare
-end)
+    type t = string
+    let compare = compare
+  end)
 
 let builtin_regexps =
   List.fold_left (fun acc (n, c) -> StringMap.add n (Sedlex.chars c) acc)
     StringMap.empty
     [
-     "any", Cset.any;
-     "eof", Cset.eof;
-     "xml_letter", Cset.letter;
-     "xml_digit", Cset.digit;
-     "xml_extender", Cset.extender;
-     "xml_base_char", Cset.base_char;
-     "xml_ideographic", Cset.ideographic;
-     "xml_combining_char", Cset.combining_char;
-     "xml_blank", Cset.blank;
-     "tr8876_ident_char", Cset.tr8876_ident_char;
+      "any", Cset.any;
+      "eof", Cset.eof;
+      "xml_letter", Cset.letter;
+      "xml_digit", Cset.digit;
+      "xml_extender", Cset.extender;
+      "xml_base_char", Cset.base_char;
+      "xml_ideographic", Cset.ideographic;
+      "xml_combining_char", Cset.combining_char;
+      "xml_blank", Cset.blank;
+      "tr8876_ident_char", Cset.tr8876_ident_char;
 
-     (* Unicode 6.3 categories *)
-     "cc", Unicode63.Categories.cc;
-     "cf", Unicode63.Categories.cf;
-     "cn", Unicode63.Categories.cn;
-     "co", Unicode63.Categories.co;
-     "cs", Unicode63.Categories.cs;
-     "ll", Unicode63.Categories.ll;
-     "lm", Unicode63.Categories.lm;
-     "lo", Unicode63.Categories.lo;
-     "lt", Unicode63.Categories.lt;
-     "lu", Unicode63.Categories.lu;
-     "mc", Unicode63.Categories.mc;
-     "me", Unicode63.Categories.me;
-     "mn", Unicode63.Categories.mn;
-     "nd", Unicode63.Categories.nd;
-     "nl", Unicode63.Categories.nl;
-     "no", Unicode63.Categories.no;
-     "pc", Unicode63.Categories.pc;
-     "pd", Unicode63.Categories.pd;
-     "pe", Unicode63.Categories.pe;
-     "pf", Unicode63.Categories.pf;
-     "pi", Unicode63.Categories.pi;
-     "po", Unicode63.Categories.po;
-     "ps", Unicode63.Categories.ps;
-     "sc", Unicode63.Categories.sc;
-     "sk", Unicode63.Categories.sk;
-     "sm", Unicode63.Categories.sm;
-     "so", Unicode63.Categories.so;
-     "zl", Unicode63.Categories.zl;
-     "zp", Unicode63.Categories.zp;
-     "zs", Unicode63.Categories.zs;
+      (* Unicode 6.3 categories *)
+      "cc", Unicode63.Categories.cc;
+      "cf", Unicode63.Categories.cf;
+      "cn", Unicode63.Categories.cn;
+      "co", Unicode63.Categories.co;
+      "cs", Unicode63.Categories.cs;
+      "ll", Unicode63.Categories.ll;
+      "lm", Unicode63.Categories.lm;
+      "lo", Unicode63.Categories.lo;
+      "lt", Unicode63.Categories.lt;
+      "lu", Unicode63.Categories.lu;
+      "mc", Unicode63.Categories.mc;
+      "me", Unicode63.Categories.me;
+      "mn", Unicode63.Categories.mn;
+      "nd", Unicode63.Categories.nd;
+      "nl", Unicode63.Categories.nl;
+      "no", Unicode63.Categories.no;
+      "pc", Unicode63.Categories.pc;
+      "pd", Unicode63.Categories.pd;
+      "pe", Unicode63.Categories.pe;
+      "pf", Unicode63.Categories.pf;
+      "pi", Unicode63.Categories.pi;
+      "po", Unicode63.Categories.po;
+      "ps", Unicode63.Categories.ps;
+      "sc", Unicode63.Categories.sc;
+      "sk", Unicode63.Categories.sk;
+      "sm", Unicode63.Categories.sm;
+      "so", Unicode63.Categories.so;
+      "zl", Unicode63.Categories.zl;
+      "zp", Unicode63.Categories.zp;
+      "zs", Unicode63.Categories.zs;
 
-     (* Unicode 6.3 properties *)
-     "alphabetic", Unicode63.Properties.alphabetic;
-     "ascii_hex_digit", Unicode63.Properties.ascii_hex_digit;
-     "hex_digit", Unicode63.Properties.hex_digit;
-     "id_continue", Unicode63.Properties.id_continue;
-     "id_start", Unicode63.Properties.id_start;
-     "lowercase", Unicode63.Properties.lowercase;
-     "math", Unicode63.Properties.math;
-     "other_alphabetic", Unicode63.Properties.other_alphabetic;
-     "other_lowercase", Unicode63.Properties.other_lowercase;
-     "other_math", Unicode63.Properties.other_math;
-     "other_uppercase", Unicode63.Properties.other_uppercase;
-     "uppercase", Unicode63.Properties.uppercase;
-     "white_space", Unicode63.Properties.white_space;
-     "xid_continue", Unicode63.Properties.xid_continue;
-     "xid_start", Unicode63.Properties.xid_start;
+      (* Unicode 6.3 properties *)
+      "alphabetic", Unicode63.Properties.alphabetic;
+      "ascii_hex_digit", Unicode63.Properties.ascii_hex_digit;
+      "hex_digit", Unicode63.Properties.hex_digit;
+      "id_continue", Unicode63.Properties.id_continue;
+      "id_start", Unicode63.Properties.id_start;
+      "lowercase", Unicode63.Properties.lowercase;
+      "math", Unicode63.Properties.math;
+      "other_alphabetic", Unicode63.Properties.other_alphabetic;
+      "other_lowercase", Unicode63.Properties.other_lowercase;
+      "other_math", Unicode63.Properties.other_math;
+      "other_uppercase", Unicode63.Properties.other_uppercase;
+      "uppercase", Unicode63.Properties.uppercase;
+      "white_space", Unicode63.Properties.white_space;
+      "xid_continue", Unicode63.Properties.xid_continue;
+      "xid_start", Unicode63.Properties.xid_start;
     ]
 
 (* Tables (indexed mapping: codepoint -> next state) *)
@@ -194,11 +194,11 @@ let partition_name x =
 let partition (name, p) =
   let rec gen_tree = function
     | Lte (i, yes, no) ->
-        [%expr if c <= [%e int i] then [%e gen_tree yes] else [%e gen_tree no]]
+      [%expr if c <= [%e int i] then [%e gen_tree yes] else [%e gen_tree no]]
     | Return i -> int i
     | Table (offset, t) ->
-              let c = if offset = 0 then [%expr c] else [%expr c - [%e int offset]] in
-        [%expr Char.code (String.get [%e evar (table_name t)] [%e c]) - 1]
+      let c = if offset = 0 then [%expr c] else [%expr c - [%e int offset]] in
+      [%expr Char.code (String.get [%e evar (table_name t)] [%e c]) - 1]
   in
   let body = gen_tree (decision_table p) in
   glb_value name (func [(pconstr "Some" [pvar "uc"],
@@ -221,8 +221,8 @@ let call_state lexbuf auto state =
   let (trans, final) = auto.(state) in
   if Array.length trans = 0
   then match best_final final with
-  | Some i -> int i
-  | None -> assert false
+    | Some i -> int i
+    | None -> assert false
   else appfun (state_fun state) [evar lexbuf]
 
 let gen_state lexbuf auto i (trans, final) =
@@ -236,9 +236,9 @@ let gen_state lexbuf auto i (trans, final) =
   in
   let ret body = [ Vb.mk (pvar (state_fun i)) (func [pvar lexbuf, body]) ] in
   match best_final final with
-    | None -> ret (body ())
-    | Some _ when Array.length trans = 0 -> []
-    | Some i -> ret [%expr Sedlexing.mark [%e evar lexbuf] [%e int i]; [%e body ()]]
+  | None -> ret (body ())
+  | Some _ when Array.length trans = 0 -> []
+  | Some i -> ret [%expr Sedlexing.mark [%e evar lexbuf] [%e int i]; [%e body ()]]
 
 let gen_definition lexbuf l error =
   let brs = Array.of_list l in
@@ -282,90 +282,90 @@ let rec repeat r = function
 let regexp_of_pattern env =
   let rec char_pair_op func name p tuple = (* Construct something like Sub(a,b) *)
     match tuple with
-      | Some {ppat_desc=Ppat_tuple (p0 :: p1 :: [])} ->
-        begin match func (aux p0) (aux p1) with
+    | Some {ppat_desc=Ppat_tuple (p0 :: p1 :: [])} ->
+      begin match func (aux p0) (aux p1) with
         | Some r -> r
         | None ->
           err p.ppat_loc @@
-            "the "^name^" operator can only applied to single-character length regexps"
-        end
-      | _ -> err p.ppat_loc @@ "the "^name^" operator requires two arguments, like "^name^"(a,b)"
+          "the "^name^" operator can only applied to single-character length regexps"
+      end
+    | _ -> err p.ppat_loc @@ "the "^name^" operator requires two arguments, like "^name^"(a,b)"
   and aux p = (* interpret one pattern node *)
     match p.ppat_desc with
     | Ppat_or (p1, p2) -> Sedlex.alt (aux p1) (aux p2)
     | Ppat_tuple (p :: pl) ->
-        List.fold_left (fun r p -> Sedlex.seq r (aux p))
-          (aux p)
-          pl
+      List.fold_left (fun r p -> Sedlex.seq r (aux p))
+        (aux p)
+        pl
     | Ppat_construct ({txt = Lident "Star"}, Some p) ->
-        Sedlex.rep (aux p)
+      Sedlex.rep (aux p)
     | Ppat_construct ({txt = Lident "Plus"}, Some p) ->
-        Sedlex.plus (aux p)
+      Sedlex.plus (aux p)
     | Ppat_construct
         ({txt = Lident "Rep"},
          Some {ppat_desc=Ppat_tuple[p0; {ppat_desc=Ppat_constant (i1 as i2)|Ppat_interval(i1, i2)}]}) ->
-         begin match Constant.of_constant i1, Constant.of_constant i2 with
-         | Pconst_integer(i1,_), Pconst_integer(i2,_) ->
-             let i1 = int_of_string i1 in
-             let i2 = int_of_string i2 in
-             if 0 <= i1 && i1 <= i2 then repeat (aux p0) (i1, i2)
-             else err p.ppat_loc "Invalid range for Rep operator"
-         | _ ->
-             err p.ppat_loc "Rep must take an integer constant or interval"
-         end
+      begin match Constant.of_constant i1, Constant.of_constant i2 with
+        | Pconst_integer(i1,_), Pconst_integer(i2,_) ->
+          let i1 = int_of_string i1 in
+          let i2 = int_of_string i2 in
+          if 0 <= i1 && i1 <= i2 then repeat (aux p0) (i1, i2)
+          else err p.ppat_loc "Invalid range for Rep operator"
+        | _ ->
+          err p.ppat_loc "Rep must take an integer constant or interval"
+      end
     | Ppat_construct ({txt = Lident "Rep"}, _) ->
-        err p.ppat_loc "the Rep operator takes 2 arguments"
+      err p.ppat_loc "the Rep operator takes 2 arguments"
     | Ppat_construct ({txt = Lident "Opt"}, Some p) ->
-        Sedlex.alt Sedlex.eps (aux p)
+      Sedlex.alt Sedlex.eps (aux p)
     | Ppat_construct ({txt = Lident "Compl"}, arg) ->
-        begin match arg with
+      begin match arg with
         | Some p0 ->
-            begin match Sedlex.compl (aux p0) with
+          begin match Sedlex.compl (aux p0) with
             | Some r -> r
             | None ->
               err p.ppat_loc
                 "the Compl operator can only applied to a single-character length regexp"
-            end
+          end
         | _ -> err p.ppat_loc "the Compl operator requires an argument"
-        end
+      end
     | Ppat_construct ({ txt = Lident "Sub" }, arg) ->
-        char_pair_op Sedlex.subtract "Sub" p arg
+      char_pair_op Sedlex.subtract "Sub" p arg
     | Ppat_construct ({ txt = Lident "Intersect" }, arg) ->
-        char_pair_op Sedlex.intersection "Intersect" p arg
+      char_pair_op Sedlex.intersection "Intersect" p arg
     | Ppat_construct ({txt = Lident "Chars"}, arg) ->
-        let const = match arg with
-          | Some {ppat_desc=Ppat_constant const} ->
-              Some (Constant.of_constant const)
-          | _ -> None
-        in
-        begin match const with
+      let const = match arg with
+        | Some {ppat_desc=Ppat_constant const} ->
+          Some (Constant.of_constant const)
+        | _ -> None
+      in
+      begin match const with
         | Some (Pconst_string(s,_))->
-            let c = ref Cset.empty in
-            for i = 0 to String.length s - 1 do
-              c := Cset.union !c (Cset.singleton (Char.code s.[i]))
-            done;
-            Sedlex.chars !c
+          let c = ref Cset.empty in
+          for i = 0 to String.length s - 1 do
+            c := Cset.union !c (Cset.singleton (Char.code s.[i]))
+          done;
+          Sedlex.chars !c
         | _ -> err p.ppat_loc "the Chars operator requires a string argument"
-        end
+      end
     | Ppat_interval (i_start, i_end) ->
-        begin match Constant.of_constant i_start, Constant.of_constant i_end with
-          | Pconst_char c1, Pconst_char c2 -> Sedlex.chars (Cset.interval (Char.code c1) (Char.code c2))
-          | Pconst_integer(i1,_), Pconst_integer(i2,_) ->
-              Sedlex.chars (Cset.interval (codepoint (int_of_string i1)) (codepoint (int_of_string i2)))
-          | _ -> err p.ppat_loc "this pattern is not a valid interval regexp"
-        end
+      begin match Constant.of_constant i_start, Constant.of_constant i_end with
+        | Pconst_char c1, Pconst_char c2 -> Sedlex.chars (Cset.interval (Char.code c1) (Char.code c2))
+        | Pconst_integer(i1,_), Pconst_integer(i2,_) ->
+          Sedlex.chars (Cset.interval (codepoint (int_of_string i1)) (codepoint (int_of_string i2)))
+        | _ -> err p.ppat_loc "this pattern is not a valid interval regexp"
+      end
     | Ppat_constant (const) ->
-        begin match Constant.of_constant const with
-          | Pconst_string (s, _) -> regexp_for_string s
-          | Pconst_char c -> regexp_for_char c
-          | Pconst_integer(i,_) -> Sedlex.chars (Cset.singleton (codepoint (int_of_string i)))
-          | _ -> err p.ppat_loc "this pattern is not a valid regexp"
-        end
+      begin match Constant.of_constant const with
+        | Pconst_string (s, _) -> regexp_for_string s
+        | Pconst_char c -> regexp_for_char c
+        | Pconst_integer(i,_) -> Sedlex.chars (Cset.singleton (codepoint (int_of_string i)))
+        | _ -> err p.ppat_loc "this pattern is not a valid regexp"
+      end
     | Ppat_var {txt=x} ->
-        begin try StringMap.find x env
+      begin try StringMap.find x env
         with Not_found ->
           err p.ppat_loc (Printf.sprintf "unbound regexp %s" x)
-        end
+      end
     | _ ->
       err p.ppat_loc "this pattern is not a valid regexp"
   in
@@ -384,31 +384,31 @@ let mapper cookies =
     method! expr e =
       match e with
       | [%expr [%sedlex [%e? {pexp_desc=Pexp_match (lexbuf, cases)}]]] ->
-            let lexbuf =
-              match lexbuf with
-              | {pexp_desc=Pexp_ident{txt=Lident lexbuf}} -> lexbuf
-              | _ ->
-                err lexbuf.pexp_loc "the matched expression must be a single identifier"
-            in
-            let cases = List.rev cases in
-            let error =
-              match List.hd cases with
-              | {pc_lhs = [%pat? _]; pc_rhs = e; pc_guard = None} -> super # expr e
-              | {pc_lhs = p} ->
-                err p.ppat_loc "the last branch must be a catch-all error case"
-            in
-            let cases = List.rev (List.tl cases) in
-            let cases =
-              List.map
-                (function
-                  | {pc_lhs = p; pc_rhs = e; pc_guard = None} -> regexp_of_pattern env p, super # expr e
-                  | {pc_guard = Some e} ->
-                    err e.pexp_loc "'when' guards are not supported"
-                ) cases
-            in
-            gen_definition lexbuf cases error
+        let lexbuf =
+          match lexbuf with
+          | {pexp_desc=Pexp_ident{txt=Lident lexbuf}} -> lexbuf
+          | _ ->
+            err lexbuf.pexp_loc "the matched expression must be a single identifier"
+        in
+        let cases = List.rev cases in
+        let error =
+          match List.hd cases with
+          | {pc_lhs = [%pat? _]; pc_rhs = e; pc_guard = None} -> super # expr e
+          | {pc_lhs = p} ->
+            err p.ppat_loc "the last branch must be a catch-all error case"
+        in
+        let cases = List.rev (List.tl cases) in
+        let cases =
+          List.map
+            (function
+              | {pc_lhs = p; pc_rhs = e; pc_guard = None} -> regexp_of_pattern env p, super # expr e
+              | {pc_guard = Some e} ->
+                err e.pexp_loc "'when' guards are not supported"
+            ) cases
+        in
+        gen_definition lexbuf cases error
       | [%expr let [%p? {ppat_desc=Ppat_var{txt=name}}] = [%sedlex.regexp? [%p? p]] in [%e? body]] ->
-          (this # define_regexp name p) # expr body
+        (this # define_regexp name p) # expr body
       | [%expr [%sedlex [%e? _]]] ->
         err e.pexp_loc "the %sedlex extension is only recognized on match expressions"
       | _ -> super # expr e
@@ -420,15 +420,15 @@ let mapper cookies =
       let mapper = ref this in
       let regexps = ref [] in
       let l = List.concat
-        (List.map
-           (function
-             | [%stri let [%p? {ppat_desc=Ppat_var{txt=name}}] = [%sedlex.regexp? [%p? p]]] as i ->
-               regexps := i :: !regexps;
-               mapper := !mapper # define_regexp name p;
-               []
-             | i ->
-               [ !mapper # structure_item i ]
-         ) l) in
+          (List.map
+             (function
+               | [%stri let [%p? {ppat_desc=Ppat_var{txt=name}}] = [%sedlex.regexp? [%p? p]]] as i ->
+                 regexps := i :: !regexps;
+                 mapper := !mapper # define_regexp name p;
+                 []
+               | i ->
+                 [ !mapper # structure_item i ]
+             ) l) in
       (l, List.rev !regexps)
 
     method! structure l =
@@ -448,7 +448,7 @@ let mapper cookies =
       else
         fst (this # structure_with_regexps l)
 
- end
+  end
 
 let () =
   Driver.register

--- a/src/syntax/sedlex.ml
+++ b/src/syntax/sedlex.ml
@@ -82,7 +82,7 @@ let compile_re re =
 (* Determinization *)
 
 type state = node list
-      (* A state of the DFA corresponds to a set of nodes in the NFA. *)
+(* A state of the DFA corresponds to a set of nodes in the NFA. *)
 
 let rec add_node state node =
   if List.memq node state then state else add_nodes (node::state) node.eps
@@ -94,8 +94,8 @@ let transition (state : state) =
   (* Merge transition with the same target *)
   let rec norm = function
     | (c1, n1)::((c2, n2)::q as l) ->
-	if n1 == n2 then norm ((Cset.union c1 c2, n1)::q)
-	else (c1, n1)::(norm l)
+      if n1 == n2 then norm ((Cset.union c1 c2, n1)::q)
+      else (c1, n1)::(norm l)
     | l -> l in
   let t = List.concat (List.map (fun n -> n.trans) state) in
   let t = norm (List.sort (fun (_, n1) (_, n2) -> n1.id - n2.id) t) in

--- a/src/syntax/sedlex.mli
+++ b/src/syntax/sedlex.mli
@@ -12,13 +12,13 @@ val plus: regexp -> regexp
 val eps: regexp
 
 val compl: regexp -> regexp option
-   (* If the argument is a single [chars] regexp, returns a regexp
-      which matches the complement set.  Otherwise returns [None]. *)
+(* If the argument is a single [chars] regexp, returns a regexp
+   which matches the complement set.  Otherwise returns [None]. *)
 val subtract: regexp -> regexp -> regexp option
-   (* If each argument is a single [chars] regexp, returns a regexp
-      which matches the set (arg1 - arg2).  Otherwise returns [None]. *)
+(* If each argument is a single [chars] regexp, returns a regexp
+   which matches the set (arg1 - arg2).  Otherwise returns [None]. *)
 val intersection: regexp -> regexp -> regexp option
-   (* If each argument is a single [chars] regexp, returns a regexp
-      which matches the intersection set.  Otherwise returns [None]. *)
+(* If each argument is a single [chars] regexp, returns a regexp
+   which matches the intersection set.  Otherwise returns [None]. *)
 
 val compile: regexp array -> ((Sedlex_cset.t * int) array * bool array) array

--- a/src/syntax/sedlex_cset.ml
+++ b/src/syntax/sedlex_cset.ml
@@ -23,11 +23,11 @@ let rec union c1 c2 =
   | [], _ -> c2
   | _, [] -> c1
   | ((i1, j1) as s1)::r1, (i2, j2)::r2 ->
-	if (i1 <= i2) then
-	  if j1 + 1 < i2 then s1::(union r1 c2)
-	  else if (j1 < j2) then union r1 ((i1, j2)::r2)
-	  else union c1 r2
-	else union c2 c1
+    if (i1 <= i2) then
+      if j1 + 1 < i2 then s1::(union r1 c2)
+      else if (j1 < j2) then union r1 ((i1, j2)::r2)
+      else union c1 r2
+    else union c2 c1
 
 let complement c =
   let rec aux start = function
@@ -35,8 +35,8 @@ let complement c =
     | (i, j)::l -> (start, i-1)::(aux (succ j) l)
   in
   match c with
-    | (-1,j)::l -> aux (succ j) l
-    | l -> aux (-1) l
+  | (-1,j)::l -> aux (succ j) l
+  | l -> aux (-1) l
 
 let intersection c1 c2 =
   complement (union (complement c1) (complement c2))


### PR DESCRIPTION
Make the size of the refill chunk configurable. Enable interactive mode by using a size of 1 instead of the default 512.