### PR TITLE
Restore OCaml 4.02.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
   - PACKAGE=sedlex
   matrix:
+  - OCAML_VERSION=4.02.3
   - OCAML_VERSION=4.03
   - OCAML_VERSION=4.04
   - OCAML_VERSION=4.05

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
   - PACKAGE=sedlex
   matrix:
-  - OCAML_SWITCH=4.02.3
+  - OCAML_VERSION=4.02 OCAML_SWITCH=4.02.3
   - OCAML_VERSION=4.03
   - OCAML_VERSION=4.04
   - OCAML_VERSION=4.05

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
   - PACKAGE=sedlex
   matrix:
-  - OCAML_VERSION=4.02.3
+  - OCAML_SWITCH=4.02.3
   - OCAML_VERSION=4.03
   - OCAML_VERSION=4.04
   - OCAML_VERSION=4.05

--- a/sedlex.opam
+++ b/sedlex.opam
@@ -14,6 +14,7 @@ depends: ["jbuilder" {build}
           "ppx_tools_versioned"
           "ocaml-migrate-parsetree"
           "gen"
+          "uchar"
          ]
 available: [ ocaml-version >= "4.02.3" ]
 homepage: "https://github.com/alainfrisch/sedlex"

--- a/src/lib/jbuild
+++ b/src/lib/jbuild
@@ -4,7 +4,7 @@
  ((name        sedlex)
   (public_name sedlex)
   (wrapped false)
-  (libraries (gen))
+  (libraries (gen uchar))
   (flags (:standard -w +A-4-9 -safe-string))
  )
 )


### PR DESCRIPTION
For now, this just adds 4.02.3 back into the support-matrix, then I hope to try and resolve any problems that Travis surfaces.

Given that the local `.opam` was never updated to indicate differently, if this works out, there should be no further local changes necessary — we can just ask opam-repository to revert ocaml/opam-repository#12589.