### PR TITLE
prepare release (v2.0)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+2.0
+     * GPR#70: Switch to dune, opam v2
+     * GPR#60: Breaking change: switch from int codepoints to Uchar.t
+       codepoints
+     * GPR#59: Track lexing position
+
+-------------------------------------------------------------------------------
+
 1.99.4
      * GPR#47: Switch to ocaml-migrate-parsetree (contributed by Adrien Guatto)
      * GPR#42: Added 'Rep' (repeat operator) (contributed by jpathy)
@@ -16,7 +24,7 @@
      * First version of sedlex.  The history below refers to ulex, the ancestor
        or sedlex implemented with Camlp4.
 
---------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 
 1.1
      * Generate (more) globally unique identifiers to avoid conflicts when open'ing another module

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ sedlex was originally written by Alain Frisch
 <alain.frisch@lexifi.com> and is now maintained as part of the
 ocaml-community repositories on github.
 
+## API
+The API is documented [here](https://ocaml-community.github.io/sedlex).
+
 ## Overview
 
 sedlex is a lexer generator for OCaml, similar to ocamllex, but

--- a/sedlex.opam
+++ b/sedlex.opam
@@ -2,7 +2,10 @@ opam-version: "2.0"
 name: "sedlex"
 synopsis: "An OCaml lexer generator for Unicode"
 description: "
-sedlex is a lexer generator for OCaml, similar to ocamllex, but supporting Unicode. Contrary to ocamllex, lexer specifications for sedlex are embedded in regular OCaml source files.
+sedlex is a lexer generator for OCaml. It is similar to ocamllex, but suppors
+Unicode. Unlike ocamllex, sedlex allows lexer specifications within regular
+OCaml source files. Lexing specific constructs are provided via a ppx syntax
+extension.
 "
 version: "2.0"
 license: "MIT"

--- a/sedlex.opam
+++ b/sedlex.opam
@@ -6,6 +6,7 @@ sedlex is a lexer generator for OCaml, similar to ocamllex, but supporting Unico
 "
 version: "2.0"
 license: "MIT"
+doc: "https://ocaml-community.github.io/sedlex/index.html"
 maintainer: "Alain Frisch <alain.frisch@lexifi.com>"
 authors: [
   "Alain Frisch <alain.frisch@lexifi.com>"

--- a/sedlex.opam
+++ b/sedlex.opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 name: "sedlex"
 synopsis: "An OCaml lexer generator for Unicode"
 description: "
-sedlex is a lexer generator for OCaml. It is similar to ocamllex, but suppors
+sedlex is a lexer generator for OCaml. It is similar to ocamllex, but supports
 Unicode. Unlike ocamllex, sedlex allows lexer specifications within regular
 OCaml source files. Lexing specific constructs are provided via a ppx syntax
 extension.

--- a/sedlex.opam
+++ b/sedlex.opam
@@ -1,7 +1,10 @@
 opam-version: "2.0"
 name: "sedlex"
 synopsis: "An OCaml lexer generator for Unicode"
-version: "1.99.5"
+description: "
+sedlex is a lexer generator for OCaml, similar to ocamllex, but supporting Unicode. Contrary to ocamllex, lexer specifications for sedlex are embedded in regular OCaml source files.
+"
+version: "2.0"
 license: "MIT"
 maintainer: "Alain Frisch <alain.frisch@lexifi.com>"
 authors: [


### PR DESCRIPTION
This just updates the CHANGES doc in preparation of a new release.
Since the switch from int codepoints to Uchar.t codepoints is a braking change -- for example, [this](https://github.com/smolkaj/ocaml-parsing/blob/master/src/Lexer.cppo.ml#L5) will no longer compile -- I changed the version number to 2.0.