### PR TITLE
Avoid warning about unused recursive flag in the generated code.

### DIFF
--- a/examples/dune
+++ b/examples/dune
@@ -3,7 +3,7 @@
  (libraries sedlex)
  (preprocess
   (pps sedlex.ppx))
-  (flags :standard -w -39))
+  (flags :standard -w +39))
 
 (alias
  (name runtest)


### PR DESCRIPTION
Sedlex always marks the function generated from [%sedlex match ...] with the recursive flag. In some cases, the function is actually not recursive and the generated code triggers a the compiler warning 39 "unused rec flag".

This patch computes the correct recursive flag and enables the warning for the example programs.