### PR TITLE
Buffer channel input.

### DIFF
--- a/src/lib/sedlexing.ml
+++ b/src/lib/sedlexing.ml
@@ -5,11 +5,25 @@
 exception InvalidCodepoint of int
 exception MalFormed
 
+let chunk_size = 512
 
 let gen_of_channel chan =
-  let f () =
-    try Some (input_char chan)
-    with End_of_file -> None
+  let buf = Bytes.create chunk_size in
+  let cached = ref (-1) in
+  let position = ref (-1) in
+  let rec f () =
+    match !position, !cached  with
+      | _, 0 ->
+          None
+      | len, c when len = c ->
+          begin
+            position := 0;
+            cached := input chan buf 0 chunk_size
+          end;
+          f ()
+      | len, _ ->
+          position := len+1;
+          Some (Bytes.get buf len)
   in
   f
 
@@ -50,8 +64,6 @@ type lexbuf = {
 
   mutable finished: bool;
 }
-
-let chunk_size = 512
 
 let empty_lexbuf = {
   refill = (fun _ _ _ -> assert false);


### PR DESCRIPTION
This is in reference to issue #45. Per the comments, `sedlex` should avoid repeatedly calling the same low-level function and use buffered calls instead.

This still does not solve the original issue since the library still expects to fill up a whole chunk of `512` characters at a time, which eventually blocks the read from the channels.

However, since channel reads are buffered with these changes, I believe that it should be possible to change the `refill` API to only do it one char at a time.