### PR TITLE
Fix typo in documentation for `lexeme_length`

### DIFF
--- a/src/lib/sedlexing.mli
+++ b/src/lib/sedlexing.mli
@@ -94,7 +94,7 @@ val loc: lexbuf -> int * int
         lexbuf)]. *)
 
 val lexeme_length: lexbuf -> int
-    (** [Sedlexing.loc lexbuf] returns the difference
+    (** [Sedlexing.lexeme_length lexbuf] returns the difference
         [(Sedlexing.lexeme_end lexbuf) - (Sedlexing.lexeme_start
         lexbuf)], that is, the length (in code points) of the matched
         string. *)


### PR DESCRIPTION
The ocamldoc attached to `Sedlexing.lexeme_length` starts with a reference to `Sedlexing.loc`, the function above it.  This looks like a straight copy-and-paste typo; this proposed commit directly replaces it with lexeme_length (but doesn't do any further adjusting).