### PR TITLE
Giving buffers better control of returned states

### DIFF
--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -173,7 +173,10 @@ let call_state lexbuf auto state =
   let (trans, final) = auto.(state) in
   if Array.length trans = 0
   then match best_final final with
-  | Some i -> int i
+  | Some i ->
+    [%expr
+      Sedlexing.mark [%e evar lexbuf] [%e int i];
+      Sedlexing.backtrack [%e evar lexbuf]]
   | None -> assert false
   else appfun (state_fun state) [evar lexbuf]
 


### PR DESCRIPTION
Currently we directly return the state number when we reached a final state without transitions. This changes the generated code so that instead of directly returning a value, we mark the value and immediately backtrack.

For a more concrete example, we are changing the generated code from
```ocaml
let rec __sedlex_state_0 =  function
  | buf ->
      (match __sedlex_partition_4 (Sedlexing.next buf) with
       | 0 -> 1
       | _ -> Sedlexing.backtrack buf)
```
to
```ocaml
let rec __sedlex_state_0 =  function
  | buf ->
      (match __sedlex_partition_4 (Sedlexing.next buf) with
       | 0 -> (Sedlexing.mark buf 1; Sedlexing.backtrack buf)
       | _ -> Sedlexing.backtrack buf)
```

This allows buffers better control over what gets returned. For example, a buffer can decide that it would be inappropriate to return the state at the current position even though we are at a final state according to the regular expressions. A use case: buffers that are aware of grapheme cluster boundaries can disallow returning after a code point which is in the middle of a grapheme cluster.

I wasn't sure how exactly to add examples/test cases for this since the buffer which comes with `sedlex` doesn't really provide any way to ignore a mark. But I do have personal project (https://github.com/ifazk/sedlying) where I ran some tests with a buffer which can ignore marks.

This closes #81 