### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/sedlex.opam
+++ b/sedlex.opam
@@ -25,7 +25,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build & >= "1.8"}
+  "dune" {>= "1.8"}
   "ppx_tools_versioned"
   "ocaml-migrate-parsetree"
   "gen"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.