### PR TITLE
Support for OCaml 4.08

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+2.2
+     * Support for OCaml 4.08
+
 2.1
      * GPR#78: Auto-generate unicode data
 

--- a/sedlex.opam
+++ b/sedlex.opam
@@ -7,7 +7,7 @@ Unicode. Unlike ocamllex, sedlex allows lexer specifications within regular
 OCaml source files. Lexing specific constructs are provided via a ppx syntax
 extension.
 "
-version: "2.1"
+version: "2.2"
 license: "MIT"
 doc: "https://ocaml-community.github.io/sedlex/index.html"
 maintainer: "Alain Frisch <alain.frisch@lexifi.com>"

--- a/sedlex.opam
+++ b/sedlex.opam
@@ -26,7 +26,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "1.8"}
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.3"}
   "ocaml-migrate-parsetree"
   "gen"
   "uchar"

--- a/src/syntax/dune
+++ b/src/syntax/dune
@@ -2,10 +2,10 @@
  (name sedlex_ppx)
  (public_name sedlex.ppx)
  (kind ppx_rewriter)
- (libraries ppx_tools_versioned.metaquot_405 ocaml-migrate-parsetree sedlex)
+ (libraries ppx_tools_versioned.metaquot_408 ocaml-migrate-parsetree sedlex)
  (ppx_runtime_libraries sedlex)
  (preprocess
-  (pps ppx_tools_versioned.metaquot_405))
+  (pps ppx_tools_versioned.metaquot_408))
  (flags (:standard -w -9)))
 
 (rule

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -4,15 +4,15 @@
 
 open Longident
 open Migrate_parsetree
-open Ast_405
+open Ast_408
 open Parsetree
 open Asttypes
 open Ast_helper
-open Ast_convenience_405
+open Ast_convenience_408
 
-module Ast_mapper_class = Ast_mapper_class_405
+module Ast_mapper_class = Ast_mapper_class_408
 
-let ocaml_version = Versions.ocaml_405
+let ocaml_version = Versions.ocaml_408
 
 module Cset = Sedlex_cset
 


### PR DESCRIPTION
In particular, this adds support for [binding operators](https://caml.inria.fr/pub/distrib/ocaml-4.08/ocaml-4.08-refman.html#s%3Abinding-operators), which are new in version 4.08.