### PR TITLE
Migrate to ppxlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src/generator/data/*.txt
 examples/complement
 examples/tokenizer
 examples/subtraction
+_opam

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ env:
   global:
   - PACKAGE=sedlex
   matrix:
-  - OCAML_VERSION=4.02
-  - OCAML_VERSION=4.03
   - OCAML_VERSION=4.04
   - OCAML_VERSION=4.05
   - OCAML_VERSION=4.06

--- a/sedlex.opam
+++ b/sedlex.opam
@@ -24,7 +24,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.04"}
   "dune" {>= "1.8"}
   "ppxlib" {>= "0.18.0"}
   "gen"

--- a/sedlex.opam
+++ b/sedlex.opam
@@ -24,7 +24,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.05"}
   "dune" {>= "1.8"}
   "ppxlib" {>= "0.18.0"}
   "gen"

--- a/sedlex.opam
+++ b/sedlex.opam
@@ -26,8 +26,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "1.8"}
-  "ppx_tools_versioned" {>= "5.2.3"}
-  "ocaml-migrate-parsetree"
+  "ppxlib" {>= "0.18.0"}
   "gen"
   "uchar"
 ]

--- a/src/syntax/dune
+++ b/src/syntax/dune
@@ -2,17 +2,20 @@
  (name sedlex_ppx)
  (public_name sedlex.ppx)
  (kind ppx_rewriter)
- (libraries ppx_tools_versioned.metaquot_408 ocaml-migrate-parsetree sedlex)
+ (libraries ppxlib sedlex)
  (ppx_runtime_libraries sedlex)
  (preprocess
-  (pps ppx_tools_versioned.metaquot_408))
- (flags (:standard -w -9)))
+  (pps ppxlib.metaquot))
+ (flags
+  (:standard -w -9)))
 
 (rule
  (targets unicode.ml)
  (mode promote-until-clean)
- (deps    (:gen ../generator/gen_unicode.exe)
-          ../generator/data/DerivedCoreProperties.txt
-          ../generator/data/DerivedGeneralCategory.txt
-          ../generator/data/PropList.txt)
- (action  (run %{gen} %{targets})))
+ (deps
+  (:gen ../generator/gen_unicode.exe)
+  ../generator/data/DerivedCoreProperties.txt
+  ../generator/data/DerivedGeneralCategory.txt
+  ../generator/data/PropList.txt)
+ (action
+  (run %{gen} %{targets})))


### PR DESCRIPTION
Having sedlex anywhere in your project's dependency tree is currently incompatible with using ocamlformat because of a conflict in the required versions of ocaml-migrate-parsetree.

This PR ports sedlex to ppxlib and therefore ocaml-migrate-parsetree >= 2.0.

Caveat: I am far from being an expert in writing PPX tools. I think my changes maintain the current behaviour of sedlex. I don't think writing an extension rewriter for `match%sedlex` is possible because we also need to register the regexps at some point. Also, I am really unsure of my usage of cookies here.

That being said, the tests seem to be passing.

Fixes https://github.com/ocaml-ppx/ppxlib/issues/144