### PR TITLE
Optimize sedlexing size and performance

### DIFF
--- a/src/lib/sedlexing.ml
+++ b/src/lib/sedlexing.ml
@@ -159,7 +159,7 @@ let next lexbuf =
     Some ret
   end
 
-let next_int lexbuf : int =
+let unsafe_next_int lexbuf : int =
   if (not lexbuf.finished) && (lexbuf.pos = lexbuf.len) then refill lexbuf;
   if lexbuf.finished && (lexbuf.pos = lexbuf.len) then -1
   else begin

--- a/src/lib/sedlexing.ml
+++ b/src/lib/sedlexing.ml
@@ -159,6 +159,15 @@ let next lexbuf =
     Some ret
   end
 
+let next_int lexbuf : int =
+  if (not lexbuf.finished) && (lexbuf.pos = lexbuf.len) then refill lexbuf;
+  if lexbuf.finished && (lexbuf.pos = lexbuf.len) then -1
+  else begin
+    let ret = lexbuf.buf.(lexbuf.pos) in
+    lexbuf.pos <- lexbuf.pos + 1;
+    if ret = (Uchar.of_int 10) then new_line lexbuf;
+    Uchar.to_int ret
+  end  
 let mark lexbuf i =
   lexbuf.marked_pos <- lexbuf.pos;
   lexbuf.marked_bol <- lexbuf.curr_bol;

--- a/src/lib/sedlexing.ml
+++ b/src/lib/sedlexing.ml
@@ -168,6 +168,7 @@ let next_int lexbuf : int =
     if ret = (Uchar.of_int 10) then new_line lexbuf;
     Uchar.to_int ret
   end  
+
 let mark lexbuf i =
   lexbuf.marked_pos <- lexbuf.pos;
   lexbuf.marked_bol <- lexbuf.curr_bol;

--- a/src/lib/sedlexing.mli
+++ b/src/lib/sedlexing.mli
@@ -151,6 +151,12 @@ val next: lexbuf -> Uchar.t option
     is exhausted, the function returns [None].
     If a ['\n'] is encountered, the tracked line number is incremented. *)
 
+val next_int : lexbuf -> int
+(** [next lexbuf] extracts the next code point from the
+    lexer buffer and increments to current position. If the input stream
+    is exhausted, the function returns -1.
+    If a ['\n'] is encountered, the tracked line number is incremented. *)
+    
 val mark: lexbuf -> int -> unit
 (** [mark lexbuf i] stores the integer [i] in the internal
     slot. The backtrack position is set to the current position. *)

--- a/src/lib/sedlexing.mli
+++ b/src/lib/sedlexing.mli
@@ -151,7 +151,7 @@ val next: lexbuf -> Uchar.t option
     is exhausted, the function returns [None].
     If a ['\n'] is encountered, the tracked line number is incremented. *)
 
-val next_int : lexbuf -> int
+val unsafe_next_int : lexbuf -> int
 (** [next lexbuf] extracts the next code point from the
     lexer buffer and increments to current position. If the input stream
     is exhausted, the function returns -1.

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -174,16 +174,6 @@ let partition (name, p) =
     [%expr fun c -> 
       [%e body]
     ]
-    (* pexp_function ~loc [
-      case 
-        ~lhs:(ppat_construct ~loc (lident_loc ~loc "Some") (Some (pvar ~loc "uc")))
-        ~guard:None
-        ~rhs:[%expr let c = Uchar.to_int uc in [%e body]];
-      case 
-        ~lhs:(ppat_construct ~loc (lident_loc ~loc "None") None)
-        ~guard:None
-        ~rhs:[%expr let c = (-1) in [%e body]]]
-        *) 
 
 (* Code generation for the automata *)
 

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -201,7 +201,7 @@ let gen_state lexbuf auto i (trans, final) =
   let cases = Array.to_list cases in
   let body () =
     pexp_match ~loc
-      (appfun (partition_name partition) [[%expr Sedlexing.next_int [%e evar ~loc lexbuf]]])
+      (appfun (partition_name partition) [[%expr Sedlexing.unsafe_next_int [%e evar ~loc lexbuf]]])
       (cases @ [case ~lhs:[%pat? _] ~guard:None ~rhs:[%expr Sedlexing.backtrack [%e evar ~loc lexbuf]]])
   in
   let ret body = [ value_binding ~loc ~pat:(pvar ~loc (state_fun i)) ~expr:(pexp_function ~loc [case ~lhs:(pvar ~loc lexbuf) ~guard:None ~rhs:body]) ] in

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -156,7 +156,7 @@ let partition (name, p) =
     | Return i -> eint ~loc:default_loc i
     | Table (offset, t) ->
               let c = if offset = 0 then [%expr c] else [%expr c - [%e eint ~loc offset]] in
-        [%expr Char.code (String.get [%e evar ~loc (table_name t)] [%e c]) - 1]
+        [%expr Char.code (String.unsafe_get [%e evar ~loc (table_name t)] [%e c]) - 1]
   in
   let body = gen_tree (decision_table p) in
   glb_value name

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -160,7 +160,10 @@ let partition (name, p) =
   in
   let body = gen_tree (decision_table p) in
   glb_value name
-    (pexp_function ~loc [
+    [%expr fun c -> 
+      [%e body]
+    ]
+    (* pexp_function ~loc [
       case 
         ~lhs:(ppat_construct ~loc (lident_loc ~loc "Some") (Some (pvar ~loc "uc")))
         ~guard:None
@@ -168,7 +171,8 @@ let partition (name, p) =
       case 
         ~lhs:(ppat_construct ~loc (lident_loc ~loc "None") None)
         ~guard:None
-        ~rhs:[%expr let c = (-1) in [%e body]]])
+        ~rhs:[%expr let c = (-1) in [%e body]]]
+        *) 
 
 (* Code generation for the automata *)
 
@@ -196,7 +200,7 @@ let gen_state lexbuf auto i (trans, final) =
   let cases = Array.to_list cases in
   let body () =
     pexp_match ~loc
-      (appfun (partition_name partition) [[%expr Sedlexing.next [%e evar ~loc lexbuf]]])
+      (appfun (partition_name partition) [[%expr Sedlexing.next_int [%e evar ~loc lexbuf]]])
       (cases @ [case ~lhs:[%pat? _] ~guard:None ~rhs:[%expr Sedlexing.backtrack [%e evar ~loc lexbuf]]])
   in
   let ret body = [ value_binding ~loc ~pat:(pvar ~loc (state_fun i)) ~expr:(pexp_function ~loc [case ~lhs:(pvar ~loc lexbuf) ~guard:None ~rhs:body]) ] in


### PR DESCRIPTION
ee20e3c used Sedlexing.next_int instead of Sedlexing.next
There are two benefits:
- generated code size reduction, we saw a huge reduction in flow lexer, from 276K to its half
- avoid an allocation in the hot loop

The other two commits are self explained, c5d0eb2 reduced its size by around 10%

This should be a non breaking change