### PR TITLE
Fix directly nested sedlex matches

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+3.2:
+    * Fix directly nested sedlex matches (@smuenzel, PR #117, Fixes: #12)
+
 3.1:
     * Updated unicode support to `15.0.0`
 

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
 (lang dune 2.8)
-(version 3.1)
+(version 3.2)
 (name sedlex)
 (source (github ocaml-community/sedlex))
 (license MIT)

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -436,7 +436,7 @@ let mapper =
             let error =
               match List.hd cases with
                 | { pc_lhs = [%pat? _]; pc_rhs = e; pc_guard = None } ->
-                    super#expression e
+                    this#expression e
                 | { pc_lhs = p } ->
                     err p.ppat_loc
                       "the last branch must be a catch-all error case"
@@ -446,7 +446,7 @@ let mapper =
               List.map
                 (function
                   | { pc_lhs = p; pc_rhs = e; pc_guard = None } ->
-                      (regexp_of_pattern env p, super#expression e)
+                      (regexp_of_pattern env p, this#expression e)
                   | { pc_guard = Some e } ->
                       err e.pexp_loc "'when' guards are not supported")
                 cases


### PR DESCRIPTION
Currently, the code pattern
```
  match%sedlex lexbuf with
  ...
  | _ ->
    match%sedlex lexbuf with
    | _ ->
```
Does not compile, because the match subexpressions are transformed with `super#expression` rather than `this#expression`.