### PR TITLE
Count lines in all cases.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 - Use `Sedlexing.{Utf8,Utf16}.from_gen` to initialize UTF8 (resp. UTF16) lexing buffers from
   string.
 - Delay raising Malformed until actually reading the malformed part of the imput. (#140)
+- Count lines in all cases (#130). Previously, certain functions for initiating the
+  lexical buffer would disable lines counting.
 
 # 3.1:
 - Fix directly nested sedlex matches (@smuenzel, PR #117, fixes: #12)

--- a/src/lib/sedlexing.ml
+++ b/src/lib/sedlexing.ml
@@ -71,11 +71,7 @@ let dummy_uchar = Uchar.of_int 0
 let nl_uchar = Uchar.of_int 10
 
 let create refill =
-  {
-    empty_lexbuf with
-    refill;
-    buf = Array.make chunk_size dummy_uchar;
-  }
+  { empty_lexbuf with refill; buf = Array.make chunk_size dummy_uchar }
 
 let set_position lexbuf position =
   lexbuf.offset <- position.Lexing.pos_cnum - lexbuf.pos;

--- a/src/lib/sedlexing.ml
+++ b/src/lib/sedlexing.ml
@@ -55,7 +55,7 @@ let empty_lexbuf =
     offset = 0;
     pos = 0;
     curr_bol = 0;
-    curr_line = 0;
+    curr_line = 1;
     start_pos = 0;
     start_bol = 0;
     start_line = 0;
@@ -75,7 +75,6 @@ let create refill =
     empty_lexbuf with
     refill;
     buf = Array.make chunk_size dummy_uchar;
-    curr_line = 1;
   }
 
 let set_position lexbuf position =
@@ -139,7 +138,7 @@ let refill lexbuf =
   if n = 0 then lexbuf.finished <- true else lexbuf.len <- lexbuf.len + n
 
 let new_line lexbuf =
-  if lexbuf.curr_line != 0 then lexbuf.curr_line <- lexbuf.curr_line + 1;
+  lexbuf.curr_line <- lexbuf.curr_line + 1;
   lexbuf.curr_bol <- lexbuf.pos + lexbuf.offset
 
 let[@inline always] next_aux some none lexbuf =


### PR DESCRIPTION
It took me a while to track this down: we are not counting position lines when parsing from a string.

Is there any reason for that? This seems pretty counter-intuitive and I imagine most users would trip on that, expecting lines to be counted properly in all cases.