### PR TITLE
Restore compat with ocaml 4.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ jobs:
           - 4.14.x
         skip-test:
           - false
+        include:
+          - os: ubuntu-latest
+            ocaml-compiler: 4.8.x
+            skip-test: true
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# dev
+- Restore compatibility with OCaml 4.08
+
 # 3.1:
 - Fix directly nested sedlex matches (@smuenzel, PR #117, fixes: #12)
 - Use explicit stdlib in generated code (@hhugo, PR #122, fixes: #115)

--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,7 @@ Unicode. Unlike ocamllex, sedlex allows lexer specifications within regular
 OCaml source files. Lexing specific constructs are provided via a ppx syntax
 extension.")
  (depends
-   (ocaml (>= 4.14))
+   (ocaml (>= 4.08))
    dune
    (ppxlib (>= 0.26.0))
    gen

--- a/sedlex.opam
+++ b/sedlex.opam
@@ -16,7 +16,7 @@ license: "MIT"
 homepage: "https://github.com/ocaml-community/sedlex"
 bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 depends: [
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.08"}
   "dune" {>= "2.8"}
   "ppxlib" {>= "0.26.0"}
   "gen"

--- a/test/dune
+++ b/test/dune
@@ -2,5 +2,7 @@
  (name sedlex_test)
  (libraries sedlex)
  (inline_tests)
+ (enabled_if
+  (>= %{ocaml_version} 4.14))
  (preprocess
   (pps sedlex.ppx ppx_expect)))


### PR DESCRIPTION
sedlex is still compatible with OCaml 4.08.

There is however no version of ppx_expect compatible with both ocaml 4.08 and  ppxlib 0.26.
I've disable the expect tests on ocaml version older than 4.14