### PR TITLE
Delay MalFormed until really needed.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 - Restore compatibility with OCaml 4.08
 - Use `Sedlexing.{Utf8,Utf16}.from_gen` to initialize UTF8 (resp. UTF16) lexing buffers from
   string.
+- Delay raising Malformed until actually reading the malformed part of the imput. (#140)
 
 # 3.1:
 - Fix directly nested sedlex matches (@smuenzel, PR #117, fixes: #12)

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -167,10 +167,19 @@ let%expect_test "utf8" =
   [%expect
     {|
     == from_string ==
+    Ident asas
+    Number 123
+    Op +
     MalFormed
     == from_gen ==
+    Ident asas
+    Number 123
+    Op +
     MalFormed
     == from_channel ==
+    Ident asas
+    Number 123
+    Op +
     MalFormed |}]
 
 let%expect_test "utf16" =
@@ -205,8 +214,14 @@ let%expect_test "utf16" =
   [%expect
     {|
     == from_string ==
+    Ident asas
+    Number 123
+    Op +
     MalFormed
     == from_gen ==
+    Ident asas
+    Number 123
+    Op +
     MalFormed
     == from_channel ==
     Ident asas
@@ -237,8 +252,10 @@ let%expect_test "utf16" =
   [%expect
     {|
     == from_string ==
+    Number 12
     MalFormed
     == from_gen ==
+    Number 12
     MalFormed
     == from_channel ==
     Number 12
@@ -247,8 +264,10 @@ let%expect_test "utf16" =
   [%expect
     {|
     == from_string ==
+    Number 12
     MalFormed
     == from_gen ==
+    Number 12
     MalFormed
     == from_channel ==
     Number 12
@@ -257,8 +276,10 @@ let%expect_test "utf16" =
   [%expect
     {|
     == from_string ==
+    Number 12
     MalFormed
     == from_gen ==
+    Number 12
     MalFormed
     == from_channel ==
     Number 12
@@ -313,8 +334,14 @@ let%expect_test "utf16-be" =
   [%expect
     {|
     == from_string ==
+    Ident asas
+    Number 123
+    Op +
     MalFormed
     == from_gen ==
+    Ident asas
+    Number 123
+    Op +
     MalFormed
     == from_channel ==
     Ident asas
@@ -345,8 +372,10 @@ let%expect_test "utf16-be" =
   [%expect
     {|
     == from_string ==
+    Number 12
     MalFormed
     == from_gen ==
+    Number 12
     MalFormed
     == from_channel ==
     Number 12
@@ -355,8 +384,10 @@ let%expect_test "utf16-be" =
   [%expect
     {|
     == from_string ==
+    Number 12
     MalFormed
     == from_gen ==
+    Number 12
     MalFormed
     == from_channel ==
     Number 12
@@ -365,8 +396,10 @@ let%expect_test "utf16-be" =
   [%expect
     {|
     == from_string ==
+    Number 12
     MalFormed
     == from_gen ==
+    Number 12
     MalFormed
     == from_channel ==
     Number 12
@@ -421,8 +454,14 @@ let%expect_test "utf16-le" =
   [%expect
     {|
     == from_string ==
+    Ident asas
+    Number 123
+    Op +
     MalFormed
     == from_gen ==
+    Ident asas
+    Number 123
+    Op +
     MalFormed
     == from_channel ==
     Ident asas
@@ -453,8 +492,10 @@ let%expect_test "utf16-le" =
   [%expect
     {|
     == from_string ==
+    Number 12
     MalFormed
     == from_gen ==
+    Number 12
     MalFormed
     == from_channel ==
     Number 12
@@ -463,8 +504,10 @@ let%expect_test "utf16-le" =
   [%expect
     {|
     == from_string ==
+    Number 12
     MalFormed
     == from_gen ==
+    Number 12
     MalFormed
     == from_channel ==
     Number 12
@@ -473,8 +516,10 @@ let%expect_test "utf16-le" =
   [%expect
     {|
     == from_string ==
+    Number 12
     MalFormed
     == from_gen ==
+    Number 12
     MalFormed
     == from_channel ==
     Number 12


### PR DESCRIPTION
replace #134
fix #133
When refilling the Uchar buffer of a lexbuf, we might encounter `MalFormed` input but the lexer might not try to read it in the end.
This PR makes sure we only raise `Malformed` when we actually need to read the problematic part of the input. The is done by raising `Malformed` only when we can't refill any uchar at all during a `refill` call.   