### PR TITLE
CI: cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,6 @@ jobs:
           opam-depext: ${{ true }}
           opam-depext-flags: --with-test
 
-      - run: opam pin add dune https://github.com/nojb/dune.git#async_io_self_pipe_win32-3.8.2
-        if: runner.os == 'Windows'
-
       - run: opam install . --with-test
 
       - run: opam exec -- make build


### PR DESCRIPTION
We can remove the `opam pin dune` now that dune 3.8.3 has been released.
https://discuss.ocaml.org/t/ann-dune-3-8-0/12291/3?u=hhugo

Let's make sure the CI is happy before merging.