### PR TITLE
fix: use correct promotion mode

### DIFF
--- a/src/syntax/dune
+++ b/src/syntax/dune
@@ -11,8 +11,7 @@
 
 (rule
  (targets unicode.ml)
- (mode
-  (promote (until-clean)))
+ (mode promote)
  (deps
   (:gen ../generator/gen_unicode.exe)
   (glob_files ../generator/data/*.txt))


### PR DESCRIPTION
`(promote (until-clean))` is ignored when `--ignore-promoted-rules` is passed in later versions of dune.

See
https://github.com/ocaml/dune/issues/4401
https://github.com/ocaml/dune/pull/5956