### PR TITLE
Defer tag writes past fixed-length neighbors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # unreleased
 - Support nested `let..in` for `[%sedlex.regexp?]` definitions
 - Add support for named captured group (#177, #178)
+- Optimize tag placement: defer tag writes past fixed-length neighbors (#193)
 
 # 3.7 (2025-10-06)
 - Update to unicode 17.0.0

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -200,6 +200,11 @@ let bind_end_only r =
   in
   (wrapped, end_tag)
 
+let tag_end tag_id r succ =
+  let end_node = new_tagged_node (Set_position tag_id) in
+  end_node.eps <- [succ];
+  r end_node
+
 let new_disc_cell () = new_tag ()
 
 let bind_disc r cell value =
@@ -343,18 +348,29 @@ let compile rs =
 
 (* High-level compilation from IR.
 
-   [compile_ir] lowers [Ir.t] patterns into low-level regexps with tag
-   annotations, then compiles them via [compile]. The lowering phase decides
-   how to allocate tags for [as] bindings:
+   The lowering phase converts [Ir.t] patterns into low-level regexps
+   with tag annotations, deciding how to allocate tags for [as] bindings:
    - [Start_plus n]: the position is [n] code points from the token start.
    - [End_minus n]: the position is [n] code points before the token end.
    - [Tag {tag; offset}]: read memory cell [tag] and add [offset].
    When both boundaries of a capture can be expressed as [Start_plus] or
    [End_minus], no memory cells are needed at all.
 
+   Tag placement is deferred as late as possible: when a fixed-length
+   element needs only one tag, the end tag is preferred over the start
+   tag so that tag writes happen after the element rather than before.
+   In sequences, boundary tags are allocated at the end of fixed-length
+   elements that follow a variable-length element, providing anchors for
+   elements further to the left.  Anchors propagate upward through
+   tuples and captures so enclosing bindings can reuse inner tags.
+
    Or-patterns [(p1 as x) | (p2 as x)] additionally use discriminator cells:
    integer values that record which branch was taken, so the code generator
-   can emit the correct position extraction at match time. *)
+   can emit the correct position extraction at match time.
+
+   After DFA construction, [optimize] eliminates dead tags (boundary
+   tags not referenced by any binding) and remaps live tags to a dense
+   range. *)
 
 type pos_expr =
   | Tag of { tag : int; offset : int }
@@ -388,6 +404,26 @@ let shift_pos pe delta =
 
 let advance pe len = shift_pos pe len
 let retreat pe len = shift_pos pe (Option.map Int.neg len)
+
+(* [prefer ~best a b]: pick the best position expression.
+   [Start_plus]/[End_minus] always beat [Tag] (no runtime tag needed).
+   [~best] selects which tag-free form is preferred: [`Start] for
+   start boundaries (a plain constant), [`End] for end boundaries
+   (relative to token end).  Among [Tag] values, [a] wins (caller
+   controls priority by argument order). *)
+let prefer ~best a b =
+  let is_best = function
+    | Some (Start_plus _) -> best = `Start
+    | Some (End_minus _) -> best = `End
+    | _ -> false
+  in
+  match (a, b) with
+    | s, _ when is_best s -> s
+    | _, s when is_best s -> s
+    | (Some (Start_plus _ | End_minus _) as s), _ -> s
+    | _, (Some (Start_plus _ | End_minus _) as s) -> s
+    | Some _, _ -> a
+    | _ -> b
 
 (* [add_discriminators branches] takes a list of [(regexp, bindings)] pairs
    from an n-ary alternation and wraps each branch with a discriminator tag
@@ -437,35 +473,48 @@ let add_discriminators (branches : (regexp * compiled_binding list) list) =
     in
     (fold_alt wrapped, List.concat_map snd wrapped))
 
-(* [lower ir ~left ~right] converts an IR pattern to a low-level regexp
-   and a list of compiled bindings. [left] and [right] are the known
-   position contexts at the start and end of this pattern element. *)
-let rec lower ~left ~right (ir : Ir.t) : regexp * compiled_binding list =
+(* [lower ir ~left ~right] converts an IR pattern to a low-level regexp,
+   a list of compiled bindings, and a pair of anchors [(start, end)].
+   [left] and [right] are the known position contexts at the start and
+   end of this pattern element.  Anchors propagate position information
+   upward so enclosing captures can reuse inner tags instead of
+   allocating new ones.  The general principle is "prefer the tag that
+   fires latest" — for start boundaries, right-retreat beats inner
+   anchor beats outer left; for end boundaries, outer right beats end
+   anchor beats start-advance. *)
+let no_anchors = (None, None)
+
+let rec lower ~left ~right (ir : Ir.t) :
+    regexp * compiled_binding list * (pos_expr option * pos_expr option) =
   match ir with
-    | Ir.Chars cset -> (chars cset, [])
-    | Ir.Eps -> (eps, [])
+    | Ir.Chars cset -> (chars cset, [], no_anchors)
+    | Ir.Eps -> (eps, [], no_anchors)
     | Ir.Star inner ->
-        let r, _ = lower ~left:None ~right:None inner in
-        (rep r, [])
+        let r, _, _ = lower ~left:None ~right:None inner in
+        (rep r, [], no_anchors)
     | Ir.Plus inner ->
-        let r, _ = lower ~left:None ~right:None inner in
-        (plus r, [])
+        let r, _, _ = lower ~left:None ~right:None inner in
+        (plus r, [], no_anchors)
     | Ir.Rep (inner, n, m) ->
-        let r, _ = lower ~left:None ~right:None inner in
-        (repeat r n m, [])
+        let r, _, _ = lower ~left:None ~right:None inner in
+        (repeat r n m, [], no_anchors)
     | Ir.Capture (name, inner) ->
         (* Named capture — try to derive each boundary from [left]/[right]
            context or [fixed_length]; allocate tags only for boundaries that
-           cannot be computed statically. Best case: 0 tags. Worst case: 2. *)
-        let r, tags = lower ~left ~right inner in
+           cannot be computed statically. Best case: 0 tags. Worst case: 2.
+           General principle: prefer the expression that fires latest
+           (delays the tag write). *)
+        let r, tags, (start_anchor, end_anchor) = lower ~left ~right inner in
         let elem_len = Ir.fixed_length inner in
+        let from_right_retreat = retreat right elem_len in
         let known_start =
-          match left with Some _ -> left | None -> retreat right elem_len
+          prefer ~best:`Start from_right_retreat
+            (prefer ~best:`Start start_anchor left)
         in
+        let from_start_advance = advance known_start elem_len in
         let known_end =
-          match right with
-            | Some _ -> right
-            | None -> advance known_start elem_len
+          prefer ~best:`End right
+            (prefer ~best:`End end_anchor from_start_advance)
         in
         let st, et, r =
           match (known_start, known_end) with
@@ -489,63 +538,142 @@ let rec lower ~left ~right (ir : Ir.t) : regexp * compiled_binding list =
                         Tag { tag = end_tag; offset = 0 },
                         wrapped ))
         in
-        (r, { name; start_pos = st; end_pos = et; disc = [] } :: tags)
+        (* Propagate [st]/[et] as anchors so enclosing captures can
+           reuse them. *)
+        ( r,
+          { name; start_pos = st; end_pos = et; disc = [] } :: tags,
+          (Some st, Some et) )
     | Ir.Alt branches ->
         let lowered = List.map (lower ~left ~right) branches in
-        add_discriminators lowered
+        let pairs = List.map (fun (r, tags, _) -> (r, tags)) lowered in
+        let r, tags = add_discriminators pairs in
+        (r, tags, no_anchors)
     | Ir.Seq elems ->
         (* Sequence — propagate left/right position contexts through elements.
            Right positions are computed right-to-left; left positions are
-           updated left-to-right after lowering each element. *)
+           updated left-to-right after lowering each element.
+           When [retreat] breaks (variable-length element or unknown
+           [right]) but the element has fixed length, allocate a
+           boundary tag at the element's end.  This tag becomes a
+           concrete anchor: subsequent elements (to the left) can
+           compute their right positions via [retreat] from the tag.
+           The tag is placed in the NFA during the fold via [tag_end]. *)
         let n = List.length elems in
         let lengths = List.map Ir.fixed_length elems in
         let lengths_arr = Array.of_list lengths in
-        (* Compute right positions (right-to-left) *)
+        let boundary_tags = Array.make n None in
         let rights = Array.make n None in
-        let () =
+        let pre_start =
           let acc = ref right in
           for i = n - 1 downto 0 do
-            rights.(i) <- !acc;
-            acc := retreat !acc lengths_arr.(i)
-          done
+            match (!acc, lengths_arr.(i)) with
+              | _, None ->
+                  rights.(i) <- !acc;
+                  acc := None
+              | None, Some _ ->
+                  let tag = new_disc_cell () in
+                  boundary_tags.(i) <- Some tag;
+                  let tag_pos = Some (Tag { tag; offset = 0 }) in
+                  rights.(i) <- tag_pos;
+                  acc := retreat tag_pos lengths_arr.(i)
+              | Some _, Some _ ->
+                  rights.(i) <- !acc;
+                  acc := retreat !acc lengths_arr.(i)
+          done;
+          !acc
         in
-        (* Fallback for [update_left]: if [advance] returns [None]
-           (because the current left is unknown or the element has
-           variable length), but the element was a [Capture] whose
-           end position is a [Tag], we can use that tag as the [left]
-           anchor for the next element — it records a runtime position.
-           [Start_plus]/[End_minus] endpoints don't help here: they
-           are already factored into [advance], so if [advance] failed,
-           they have nothing more to offer. *)
-        let left_from_end_tag ir tags' =
-          match ir with
-            | Ir.Capture _ -> (
-                match tags' with
-                  | { end_pos = Tag _ as et; _ } :: _ -> Some et
-                  | _ -> None)
-            | _ -> None
-        in
-        let update_left cur i ir tags' =
+        (* [update_left cur i ea]: compute the left position for the
+           next element after processing element [i].
+           1. [advance] — known left + fixed-length element
+           2. [ea] — end anchor from the element (alias end tag,
+              tuple boundary anchor, etc.)
+           3. [boundary_tags.(i)] — boundary tag from rights pass *)
+        let update_left cur i ea =
           match advance cur lengths_arr.(i) with
             | Some _ as s -> s
-            | None -> left_from_end_tag ir tags'
+            | None -> (
+                match ea with
+                  | Some _ -> ea
+                  | None -> (
+                      match boundary_tags.(i) with
+                        | Some tag -> Some (Tag { tag; offset = 0 })
+                        | None -> None))
         in
         let elems_arr = Array.of_list elems in
-        let r0, tags0 = lower ~left ~right:rights.(0) elems_arr.(0) in
-        let left0 = update_left left 0 elems_arr.(0) tags0 in
-        let _, _, r_acc, tags_acc =
+        let r0, tags0, (start0, end0) =
+          lower ~left ~right:rights.(0) elems_arr.(0)
+        in
+        let r0 =
+          match boundary_tags.(0) with
+            | Some tag -> tag_end tag r0
+            | None -> r0
+        in
+        let left0 = update_left left 0 end0 in
+        let _, _, r_acc, tags_acc, last_end =
           Array.fold_left
-            (fun (i, cur_left, r_acc, tags_acc) ir_elem ->
-              if i = 0 then (1, left0, r_acc, tags_acc)
+            (fun (i, cur_left, r_acc, tags_acc, _prev_end) ir_elem ->
+              if i = 0 then (1, left0, r_acc, tags_acc, end0)
               else (
-                let r', tags' =
+                let r', tags', (_sa, ea) =
                   lower ~left:cur_left ~right:rights.(i) ir_elem
                 in
-                let new_left = update_left cur_left i ir_elem tags' in
-                (i + 1, new_left, seq r_acc r', tags_acc @ tags')))
-            (0, left, r0, tags0) elems_arr
+                let r' =
+                  match boundary_tags.(i) with
+                    | Some tag -> tag_end tag r'
+                    | None -> r'
+                in
+                let new_left = update_left cur_left i ea in
+                (i + 1, new_left, seq r_acc r', tags_acc @ tags', ea)))
+            (0, left, r0, tags0, end0) elems_arr
         in
-        (r_acc, tags_acc)
+        let end_anchor = prefer ~best:`End rights.(n - 1) last_end in
+        let start_anchor = prefer ~best:`Start pre_start start0 in
+        (r_acc, tags_acc, (start_anchor, end_anchor))
+
+let optimize ~live (compiled : compiled) : compiled * int array =
+  if compiled.num_tags = 0 then (compiled, Array.make 0 0)
+  else (
+    (* Build mapping: old tag → new tag (dense). Dead tags map to -1. *)
+    let mapping = Array.make compiled.num_tags (-1) in
+    let next = ref 0 in
+    List.iter
+      (fun tag ->
+        if tag >= 0 && tag < compiled.num_tags && mapping.(tag) = -1 then begin
+          mapping.(tag) <- !next;
+          incr next
+        end)
+      live;
+    let new_num_tags = !next in
+    if new_num_tags = compiled.num_tags then
+      (compiled, Array.init compiled.num_tags Fun.id)
+    else (
+      let remap_op = function
+        | Set_position tag ->
+            if mapping.(tag) >= 0 then Some (Set_position mapping.(tag))
+            else None
+        | Set_value (cell, v) ->
+            if mapping.(cell) >= 0 then Some (Set_value (mapping.(cell), v))
+            else None
+      in
+      let remap_ops ops = List.filter_map remap_op ops in
+      let dfa =
+        Array.map
+          (fun state ->
+            {
+              trans =
+                Array.map
+                  (fun (cset, target, ops) -> (cset, target, remap_ops ops))
+                  state.trans;
+              finals = state.finals;
+            })
+          compiled.dfa
+      in
+      ( {
+          dfa;
+          init_tags = remap_ops compiled.init_tags;
+          num_tags = new_num_tags;
+        },
+        mapping )))
 
 let compile_ir (rules : Ir.t array) =
   Array.iter (fun ir -> Ir.check_invariant ir) rules;
@@ -556,9 +684,43 @@ let compile_ir (rules : Ir.t array) =
         lower ~left:(Some (Start_plus 0)) ~right:(Some (End_minus 0)) ir)
       rules
   in
-  let regexps = Array.map fst lowered in
-  let bindings = Array.map snd lowered in
+  let regexps = Array.map (fun (r, _, _) -> r) lowered in
+  let bindings = Array.map (fun (_, tags, _) -> tags) lowered in
   let compiled = compile regexps in
+  (* Collect live tags from all bindings and optimize. *)
+  let live_tags =
+    let collect_tag acc = function
+      | Tag { tag; _ } -> tag :: acc
+      | Start_plus _ | End_minus _ -> acc
+    in
+    let collect_disc acc (cell, _) = cell :: acc in
+    let collect_binding acc (b : compiled_binding) =
+      let acc = collect_tag acc b.start_pos in
+      let acc = collect_tag acc b.end_pos in
+      List.fold_left collect_disc acc b.disc
+    in
+    Array.fold_left
+      (fun acc rule_bindings ->
+        List.fold_left collect_binding acc rule_bindings)
+      [] bindings
+  in
+  let compiled, mapping = optimize ~live:live_tags compiled in
+  let remap_pos = function
+    | Tag { tag; offset } -> Tag { tag = mapping.(tag); offset }
+    | (Start_plus _ | End_minus _) as p -> p
+  in
+  let remap_disc (cell, v) = (mapping.(cell), v) in
+  let bindings =
+    Array.map
+      (List.map (fun (b : compiled_binding) ->
+           {
+             name = b.name;
+             start_pos = remap_pos b.start_pos;
+             end_pos = remap_pos b.end_pos;
+             disc = List.map remap_disc b.disc;
+           }))
+      bindings
+  in
   {
     dfa = compiled.dfa;
     init_tags = compiled.init_tags;

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -405,25 +405,17 @@ let shift_pos pe delta =
 let advance pe len = shift_pos pe len
 let retreat pe len = shift_pos pe (Option.map Int.neg len)
 
-(* [prefer ~best a b]: pick the best position expression.
-   [Start_plus]/[End_minus] always beat [Tag] (no runtime tag needed).
-   [~best] selects which tag-free form is preferred: [`Start] for
-   start boundaries (a plain constant), [`End] for end boundaries
-   (relative to token end).  Among [Tag] values, [a] wins (caller
-   controls priority by argument order). *)
-let prefer ~best a b =
-  let is_best = function
-    | Some (Start_plus _) -> best = `Start
-    | Some (End_minus _) -> best = `End
-    | _ -> false
+(* [prefer a b]: pick the best position expression.
+   [Start_plus] > [End_minus] > [Tag] (fewer runtime operations).
+   Among equal-rank values, [a] wins. *)
+let prefer a b =
+  let rank = function
+    | Some (Start_plus _) -> 2
+    | Some (End_minus _) -> 1
+    | Some (Tag _) -> 0
+    | None -> -1
   in
-  match (a, b) with
-    | s, _ when is_best s -> s
-    | _, s when is_best s -> s
-    | (Some (Start_plus _ | End_minus _) as s), _ -> s
-    | _, (Some (Start_plus _ | End_minus _) as s) -> s
-    | Some _, _ -> a
-    | _ -> b
+  if rank a >= rank b then a else b
 
 (* [add_discriminators branches] takes a list of [(regexp, bindings)] pairs
    from an n-ary alternation and wraps each branch with a discriminator tag
@@ -508,14 +500,10 @@ let rec lower ~left ~right (ir : Ir.t) :
         let elem_len = Ir.fixed_length inner in
         let from_right_retreat = retreat right elem_len in
         let known_start =
-          prefer ~best:`Start from_right_retreat
-            (prefer ~best:`Start start_anchor left)
+          prefer from_right_retreat (prefer start_anchor left)
         in
         let from_start_advance = advance known_start elem_len in
-        let known_end =
-          prefer ~best:`End right
-            (prefer ~best:`End end_anchor from_start_advance)
-        in
+        let known_end = prefer right (prefer end_anchor from_start_advance) in
         let st, et, r =
           match (known_start, known_end) with
             | Some st, Some et -> (st, et, r)
@@ -604,9 +592,7 @@ let rec lower ~left ~right (ir : Ir.t) :
           lower ~left ~right:rights.(0) elems_arr.(0)
         in
         let r0 =
-          match boundary_tags.(0) with
-            | Some tag -> tag_end tag r0
-            | None -> r0
+          match boundary_tags.(0) with Some tag -> tag_end tag r0 | None -> r0
         in
         let left0 = update_left left 0 end0 in
         let _, _, r_acc, tags_acc, last_end =
@@ -626,8 +612,8 @@ let rec lower ~left ~right (ir : Ir.t) :
                 (i + 1, new_left, seq r_acc r', tags_acc @ tags', ea)))
             (0, left, r0, tags0, end0) elems_arr
         in
-        let end_anchor = prefer ~best:`End rights.(n - 1) last_end in
-        let start_anchor = prefer ~best:`Start pre_start start0 in
+        let end_anchor = prefer rights.(n - 1) last_end in
+        let start_anchor = prefer pre_start start0 in
         (r_acc, tags_acc, (start_anchor, end_anchor))
 
 let optimize ~live (compiled : compiled) : compiled * int array =

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -479,9 +479,9 @@ let rec lower ~left ~right (ir : Ir.t) : regexp * compiled_binding list =
             | None, None -> (
                 match elem_len with
                   | Some len ->
-                      let wrapped, start_tag = bind_start_only r in
-                      ( Tag { tag = start_tag; offset = 0 },
-                        Tag { tag = start_tag; offset = len },
+                      let wrapped, end_tag = bind_end_only r in
+                      ( Tag { tag = end_tag; offset = -len },
+                        Tag { tag = end_tag; offset = 0 },
                         wrapped )
                   | None ->
                       let wrapped, start_tag, end_tag = bind r in

--- a/src/compiler/sedlex.mli
+++ b/src/compiler/sedlex.mli
@@ -87,6 +87,11 @@ val bind_start_only : regexp -> regexp * int
     start position can be computed from a known offset. *)
 val bind_end_only : regexp -> regexp * int
 
+(** [tag_end tag_id r] wraps [r] with a pre-allocated end tag: the NFA becomes
+    [r → [tag_id] → successor]. Unlike [bind_end_only], does not allocate a
+    fresh tag — uses the given [tag_id]. *)
+val tag_end : int -> regexp -> regexp
+
 (** Reset the tag counter. Called before compiling each [match%sedlex] block. *)
 val reset_tags : unit -> unit
 
@@ -154,6 +159,14 @@ type compiled_ir = {
   bindings : compiled_binding list array;
       (** [bindings.(i)] is the list of binding info for rule [i]. *)
 }
+
+(** [optimize ~live compiled] eliminates dead tags and remaps live ones to a
+    dense range. [live] is a list of tag IDs that are referenced in the
+    generated code. Tags not in [live] are stripped from all DFA transitions and
+    [init_tags], and [num_tags] is reduced accordingly. Returns the optimized
+    compiled result and a mapping array [old_tag → new_tag] ([-1] for dead tags,
+    identity when nothing changed). *)
+val optimize : live:int list -> compiled -> compiled * int array
 
 (** [compile_ir rules] compiles an array of IR patterns into a tagged DFA.
     Raises [Assert_failure] if invariant checking fails. *)

--- a/test/codegen/test_gen.ml
+++ b/test/codegen/test_gen.ml
@@ -603,6 +603,167 @@ let%expect_test "optim: element-length (Offset_from_tag)" =
     | _ -> ()
     |}]
 
+(* Optimization 1b: Deferred start tag past fixed-length prefix
+   When an as-binding wraps a tuple that starts with fixed-length
+   elements followed by variable-length, the start tag is placed
+   after the prefix instead of at the very beginning.
+   Example: ("0x", Plus hexa) as x — start tag fires after "0x". *)
+let%expect_test "optim: deferred start tag past prefix" =
+  (match%sedlex_test buf with
+    | Plus 'a', (("0x", Plus ('0' .. '9' | 'a' .. 'f')) as x), Plus 'b' ->
+        ignore x
+    | _ -> ());
+  [%expect
+    {|
+    DOT:
+    digraph {
+      rankdir=LR;
+      node [shape=circle];
+
+      _start [shape=point];
+      _start -> state0;
+
+      state0 [label="0"];
+      state0 -> state1 [label="'a'"];
+      state1 [label="1"];
+      state1 -> state2 [label="'0'"];
+      state1 -> state1 [label="'a'"];
+      state2 [label="2"];
+      state2 -> state3 [label="'x' {t0}"];
+      state3 [label="3"];
+      state3 -> state4 [label="'0'-'9', 'a'-'f' {t1}"];
+      state4 [label="4"];
+      state4 -> state4 [label="'0'-'9', 'a', 'c'-'f' {t1}"];
+      state4 -> state5 [label="'b' {t1}"];
+      state5 [label="5\n[rule 0]", shape=doublecircle];
+      state5 -> state4 [label="'0'-'9', 'a', 'c'-'f' {t1}"];
+      state5 -> state5 [label="'b' {t1}"];
+    }
+    CODE:
+    let rec __sedlex_state_0 buf =
+      match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_1 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_1 buf =
+      match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_2 buf
+      | 1 -> __sedlex_state_1 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_2 buf =
+      match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_3 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_3 buf =
+      match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_4 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_4 buf =
+      match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_4 buf)
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_5 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_5 buf =
+      Sedlexing.mark buf 0;
+      (match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
+       | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_4 buf)
+       | 1 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_5 buf)
+       | _ -> Sedlexing.backtrack buf) in
+    match Sedlexing.start buf;
+          Sedlexing.__private__init_mem buf 2;
+          __sedlex_state_0 buf
+    with
+    | 0 ->
+        let x =
+          let __s = (Sedlexing.__private__mem_pos buf 0) + (-2) in
+          let __e = Sedlexing.__private__mem_pos buf 1 in
+          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+        ignore x
+    | _ -> ()
+    |}]
+
+(* Optimization 1c: Nested alias anchor propagation
+   When aliases are nested, the inner alias's tag positions should
+   propagate as anchors to the outer alias.
+   Example: ((Plus 'a' as x) as y) — y should reuse x's tags. *)
+let%expect_test "optim: nested alias anchor propagation" =
+  (match%sedlex_test buf with
+    | ( Plus 'a',
+        (("0x", (Plus ('0' .. '9' | 'a' .. 'f') as hex)) as full),
+        Plus 'b' ) ->
+        ignore (hex, full)
+    | _ -> ());
+  [%expect
+    {|
+    DOT:
+    digraph {
+      rankdir=LR;
+      node [shape=circle];
+
+      _start [shape=point];
+      _start -> state0;
+
+      state0 [label="0"];
+      state0 -> state1 [label="'a'"];
+      state1 [label="1"];
+      state1 -> state2 [label="'0'"];
+      state1 -> state1 [label="'a'"];
+      state2 [label="2"];
+      state2 -> state3 [label="'x' {t0}"];
+      state3 [label="3"];
+      state3 -> state4 [label="'0'-'9', 'a'-'f' {t1}"];
+      state4 [label="4"];
+      state4 -> state4 [label="'0'-'9', 'a', 'c'-'f' {t1}"];
+      state4 -> state5 [label="'b' {t1}"];
+      state5 [label="5\n[rule 0]", shape=doublecircle];
+      state5 -> state4 [label="'0'-'9', 'a', 'c'-'f' {t1}"];
+      state5 -> state5 [label="'b' {t1}"];
+    }
+    CODE:
+    let rec __sedlex_state_0 buf =
+      match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_1 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_1 buf =
+      match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_2 buf
+      | 1 -> __sedlex_state_1 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_2 buf =
+      match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_3 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_3 buf =
+      match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_4 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_4 buf =
+      match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_4 buf)
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_5 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_5 buf =
+      Sedlexing.mark buf 0;
+      (match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
+       | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_4 buf)
+       | 1 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_5 buf)
+       | _ -> Sedlexing.backtrack buf) in
+    match Sedlexing.start buf;
+          Sedlexing.__private__init_mem buf 2;
+          __sedlex_state_0 buf
+    with
+    | 0 ->
+        let full =
+          let __s = (Sedlexing.__private__mem_pos buf 0) + (-2) in
+          let __e = Sedlexing.__private__mem_pos buf 1 in
+          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+        let hex =
+          let __s = Sedlexing.__private__mem_pos buf 0 in
+          let __e = Sedlexing.__private__mem_pos buf 1 in
+          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+        ignore (hex, full)
+    | _ -> ()
+    |}]
+
 (* Optimization 2: Or-pattern offset propagation
    When an or-pattern is at the top level of a rule, as-bindings
    covering the whole branch should get Start_plus 0 / End_minus 0

--- a/test/codegen/test_gen.ml
+++ b/test/codegen/test_gen.ml
@@ -159,8 +159,7 @@ let%expect_test "as binding: simple" =
     | 0 ->
         let x =
           let __s = 1 in
-          let __e = (Sedlexing.lexeme_length buf) - 1 in
-          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+          let __e = 2 in { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         ignore x
     | _ -> ()
     |}]
@@ -241,12 +240,10 @@ let%expect_test "as binding: multiple bindings" =
     | 0 ->
         let x =
           let __s = 0 in
-          let __e = (Sedlexing.lexeme_length buf) - 2 in
-          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+          let __e = 1 in { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         let y =
           let __s = 1 in
-          let __e = (Sedlexing.lexeme_length buf) - 1 in
-          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+          let __e = 2 in { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         ignore (x, y)
     | _ -> ()
     |}]
@@ -364,11 +361,11 @@ let%expect_test "as binding: shared prefix or-pattern" =
           if (Sedlexing.__private__mem_value buf 0) = 0
           then
             let __s = 0 in
-            let __e = (Sedlexing.lexeme_length buf) - 3 in
+            let __e = 3 in
             { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) }
           else
             (let __s = 1 in
-             let __e = (Sedlexing.lexeme_length buf) - 2 in
+             let __e = 4 in
              { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) }) in
         ignore x
     | _ -> ()
@@ -398,7 +395,7 @@ let%expect_test "as binding: 3-way or reuses disc cell" =
       state3 -> state4 [label="'d' {d0=0}"];
       state3 -> state6 [label="'e' {d0=1}"];
       state4 [label="4\n[rule 0]", shape=doublecircle];
-      state4 -> state5 [label="'f' {d0=0}"];
+      state4 -> state5 [label="'f' {d0=2}"];
       state5 [label="5\n[rule 0]", shape=doublecircle];
       state6 [label="6\n[rule 0]", shape=doublecircle];
     }
@@ -423,7 +420,7 @@ let%expect_test "as binding: 3-way or reuses disc cell" =
     and __sedlex_state_4 buf =
       Sedlexing.mark buf 0;
       (match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
-       | 0 -> (Sedlexing.__private__set_mem_value buf 0 0; 0)
+       | 0 -> (Sedlexing.__private__set_mem_value buf 0 2; 0)
        | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf;
           Sedlexing.__private__init_mem buf 1;
@@ -434,17 +431,17 @@ let%expect_test "as binding: 3-way or reuses disc cell" =
           if (Sedlexing.__private__mem_value buf 0) = 0
           then
             let __s = 0 in
-            let __e = (Sedlexing.lexeme_length buf) - 2 in
+            let __e = 2 in
             { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) }
           else
             if (Sedlexing.__private__mem_value buf 0) = 1
             then
               (let __s = 0 in
-               let __e = (Sedlexing.lexeme_length buf) - 3 in
+               let __e = 1 in
                { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) })
             else
               (let __s = 0 in
-               let __e = (Sedlexing.lexeme_length buf) - 2 in
+               let __e = 3 in
                { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) }) in
         ignore x
     | _ -> ()
@@ -493,8 +490,7 @@ let%expect_test "as binding: multi-rule" =
     | 0 ->
         let x =
           let __s = 1 in
-          let __e = Sedlexing.lexeme_length buf in
-          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+          let __e = 2 in { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         ignore x
     | 1 -> ()
     | _ -> ()
@@ -531,8 +527,7 @@ let%expect_test "as binding: wrapping alternation" =
     | 0 ->
         let y =
           let __s = 1 in
-          let __e = Sedlexing.lexeme_length buf in
-          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+          let __e = 2 in { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         ignore y
     | _ -> ()
     |}]
@@ -1425,13 +1420,13 @@ let%expect_test "as binding: or-chain then nested or on right" =
           if (Sedlexing.__private__mem_value buf 1) = 0
           then
             let __s = 0 in
-            let __e = (Sedlexing.lexeme_length buf) - 2 in
+            let __e = 2 in
             { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) }
           else
             if (Sedlexing.__private__mem_value buf 1) = 1
             then
               (let __s = 0 in
-               let __e = (Sedlexing.lexeme_length buf) - 3 in
+               let __e = 1 in
                { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) })
             else
               if
@@ -1439,23 +1434,23 @@ let%expect_test "as binding: or-chain then nested or on right" =
                   ((Sedlexing.__private__mem_value buf 0) = 0)
               then
                 (let __s = 0 in
-                 let __e = (Sedlexing.lexeme_length buf) - 3 in
+                 let __e = 3 in
                  { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) })
               else
                 (let __s = 0 in
-                 let __e = (Sedlexing.lexeme_length buf) - 4 in
+                 let __e = 1 in
                  { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) }) in
         let y =
           if (Sedlexing.__private__mem_value buf 1) = 0
           then
             let __s = 2 in
-            let __e = Sedlexing.lexeme_length buf in
+            let __e = 4 in
             { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) }
           else
             if (Sedlexing.__private__mem_value buf 1) = 1
             then
               (let __s = 1 in
-               let __e = Sedlexing.lexeme_length buf in
+               let __e = 4 in
                { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) })
             else
               (let __s = (Sedlexing.lexeme_length buf) - 2 in

--- a/test/codegen/test_gen.ml
+++ b/test/codegen/test_gen.ml
@@ -562,10 +562,10 @@ let%expect_test "optim: element-length (Offset_from_tag)" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'a' {t0}"];
+      state0 -> state1 [label="'a'"];
       state1 [label="1"];
-      state1 -> state1 [label="'a' {t0}"];
-      state1 -> state2 [label="'b'"];
+      state1 -> state1 [label="'a'"];
+      state1 -> state2 [label="'b' {t0}"];
       state2 [label="2"];
       state2 -> state3 [label="'c'"];
       state3 [label="3\n[rule 0]", shape=doublecircle];
@@ -574,12 +574,12 @@ let%expect_test "optim: element-length (Offset_from_tag)" =
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 0 -> __sedlex_state_1 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
-      | 1 -> __sedlex_state_2 buf
+      | 0 -> __sedlex_state_1 buf
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_2 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
@@ -596,8 +596,8 @@ let%expect_test "optim: element-length (Offset_from_tag)" =
     with
     | 0 ->
         let x =
-          let __s = Sedlexing.__private__mem_pos buf 0 in
-          let __e = (Sedlexing.__private__mem_pos buf 0) + 1 in
+          let __s = (Sedlexing.__private__mem_pos buf 0) + (-1) in
+          let __e = Sedlexing.__private__mem_pos buf 0 in
           { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         ignore x
     | _ -> ()

--- a/test/codegen/test_realistic.ml
+++ b/test/codegen/test_realistic.ml
@@ -178,12 +178,10 @@ let%expect_test "realistic: multi-token lexer" =
     | 3 ->
         let x =
           let __s = 1 in
-          let __e = (Sedlexing.lexeme_length buf) - 3 in
-          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+          let __e = 2 in { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         let y =
           let __s = 3 in
-          let __e = (Sedlexing.lexeme_length buf) - 1 in
-          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+          let __e = 4 in { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         ignore (x, y)
     | 4 ->
         let tok =

--- a/test/codegen/test_realistic.ml
+++ b/test/codegen/test_realistic.ml
@@ -1,9 +1,9 @@
 (* Realistic multi-rule lexer exercising many patterns simultaneously.
    Current: init_mem 2.
    - Rule 0: (Plus 'a'..'z' as ns), '.', (Plus 'a'..'z' as name) → 1 tag
-     (ns: start=0, end=tag0; name: start=tag0+1 via Tag offset, end=lexeme_length)
+     (tag deferred past '.': ns: start=0, end=tag1-1; name: start=tag1, end=lexeme_length)
    - Rule 1: (Plus 'A'..'Z' as label), '=', (Plus '0'..'9' as value) → 1 tag
-     (label: start=0, end=tag1; value: start=tag1+1 via Tag offset, end=lexeme_length)
+     (tag deferred past '=': label: start=0, end=tag0-1; value: start=tag0, end=lexeme_length)
    - Rule 2: "0x", (Plus hex as hex), ';' → 0 tags (prefix=2, suffix=1)
    - Rule 3: '(', ('a'..'z' as x), ',', ('a'..'z' as y), ')' → 0 tags (all fixed offsets)
    - Rule 4: (Plus digits as tok) | (Plus letters as tok) → 0 tags (discriminator elided)
@@ -34,8 +34,8 @@ let%expect_test "realistic: multi-token lexer" =
       state0 -> state1 [label="'('"];
       state0 -> state6 [label="'0'"];
       state0 -> state7 [label="'1'-'9'"];
-      state0 -> state11 [label="'A'-'Z' {t1}"];
-      state0 -> state14 [label="'a'-'z' {t0}"];
+      state0 -> state11 [label="'A'-'Z'"];
+      state0 -> state14 [label="'a'-'z'"];
       state1 [label="1"];
       state1 -> state2 [label="'a'-'z'"];
       state2 [label="2"];
@@ -57,15 +57,15 @@ let%expect_test "realistic: multi-token lexer" =
       state9 -> state10 [label="';'"];
       state10 [label="10\n[rule 2]", shape=doublecircle];
       state11 [label="11"];
-      state11 -> state12 [label="'='"];
-      state11 -> state11 [label="'A'-'Z' {t1}"];
+      state11 -> state12 [label="'=' {t0}"];
+      state11 -> state11 [label="'A'-'Z'"];
       state12 [label="12"];
       state12 -> state13 [label="'0'-'9'"];
       state13 [label="13\n[rule 1]", shape=doublecircle];
       state13 -> state13 [label="'0'-'9'"];
       state14 [label="14\n[rule 4]", shape=doublecircle];
-      state14 -> state15 [label="'.'"];
-      state14 -> state14 [label="'a'-'z' {t0}"];
+      state14 -> state15 [label="'.' {t1}"];
+      state14 -> state14 [label="'a'-'z'"];
       state15 [label="15"];
       state15 -> state16 [label="'a'-'z'"];
       state16 [label="16\n[rule 0]", shape=doublecircle];
@@ -77,8 +77,8 @@ let%expect_test "realistic: multi-token lexer" =
       | 0 -> __sedlex_state_1 buf
       | 1 -> __sedlex_state_6 buf
       | 2 -> __sedlex_state_7 buf
-      | 3 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_11 buf)
-      | 4 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_14 buf)
+      | 3 -> __sedlex_state_11 buf
+      | 4 -> __sedlex_state_14 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
@@ -118,8 +118,8 @@ let%expect_test "realistic: multi-token lexer" =
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_11 buf =
       match __sedlex_partition_9 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_12 buf
-      | 1 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_11 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_12 buf)
+      | 1 -> __sedlex_state_11 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_12 buf =
       match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
@@ -133,8 +133,8 @@ let%expect_test "realistic: multi-token lexer" =
     and __sedlex_state_14 buf =
       Sedlexing.mark buf 4;
       (match __sedlex_partition_10 (Sedlexing.__private__next_int buf) with
-       | 0 -> __sedlex_state_15 buf
-       | 1 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_14 buf)
+       | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_15 buf)
+       | 1 -> __sedlex_state_14 buf
        | _ -> Sedlexing.backtrack buf)
     and __sedlex_state_15 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
@@ -152,20 +152,20 @@ let%expect_test "realistic: multi-token lexer" =
     | 0 ->
         let ns =
           let __s = 0 in
-          let __e = Sedlexing.__private__mem_pos buf 0 in
+          let __e = (Sedlexing.__private__mem_pos buf 1) + (-1) in
           { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         let name =
-          let __s = (Sedlexing.__private__mem_pos buf 0) + 1 in
+          let __s = Sedlexing.__private__mem_pos buf 1 in
           let __e = Sedlexing.lexeme_length buf in
           { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         ignore (ns, name)
     | 1 ->
         let label =
           let __s = 0 in
-          let __e = Sedlexing.__private__mem_pos buf 1 in
+          let __e = (Sedlexing.__private__mem_pos buf 0) + (-1) in
           { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         let value =
-          let __s = (Sedlexing.__private__mem_pos buf 1) + 1 in
+          let __s = Sedlexing.__private__mem_pos buf 0 in
           let __e = Sedlexing.lexeme_length buf in
           { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         ignore (label, value)


### PR DESCRIPTION
## Summary

- Prefer end tag over start tag for fixed-length element optimization — delays the tag write past the element
- Allocate boundary tags for fixed-length tuple elements without a right-position anchor, so that as-binding tags fire as late as possible in the automaton
- Dead tag elimination pass (`Sedlex.optimize`) strips unused boundary tags and remaps live ones to a dense range
- Inner tuples communicate boundary anchors to enclosing aliases via `aux`'s return triple

## Test plan
- [ ] Existing expect tests pass (codegen, realistic, basic)
- [ ] New test: deferred start tag past inner prefix (`("0x", Plus hexa) as x`)
- [ ] Verify dead boundary tags are eliminated (mem_cells unchanged for patterns without aliases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)