### PR TITLE
Rewrite determinization as a Laurikari TDFA for correct capture semantics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # unreleased
 - Support nested `let..in` for `[%sedlex.regexp?]` definitions
 - Add support for named captured group (#177, #178)
+- Rewrite determinization as a Laurikari tagged DFA, fixing incorrect
+  submatch positions when a repetition loop overlaps a capture (#199)
 
 # 3.7 (2025-10-06)
 - Update to unicode 17.0.0

--- a/dune-project
+++ b/dune-project
@@ -27,4 +27,5 @@ extension.")
    (ppxlib (>= 0.26.0))
    gen
    (ppx_expect :with-test)
+   (qcheck-core :with-test)
    (menhir :with-test)))

--- a/sedlex.opam
+++ b/sedlex.opam
@@ -22,6 +22,7 @@ depends: [
   "ppxlib" {>= "0.26.0"}
   "gen"
   "ppx_expect" {with-test}
+  "qcheck-core" {with-test}
   "menhir" {with-test}
   "odoc" {with-doc}
 ]

--- a/src/compiler/cset.ml
+++ b/src/compiler/cset.ml
@@ -74,5 +74,10 @@ let complement c =
   in
   match c with (-1, j) :: l -> aux (succ j) l | l -> aux (-1) l
 
+let rec mem c = function
+  | [] -> false
+  | (lo, hi) :: rest ->
+      if c < lo then false else if c <= hi then true else mem c rest
+
 let intersection c1 c2 = complement (union (complement c1) (complement c2))
 let difference c1 c2 = complement (union (complement c1) c2)

--- a/src/compiler/cset.mli
+++ b/src/compiler/cset.mli
@@ -23,4 +23,5 @@ val is_empty : t -> bool
 val eof : t
 val singleton : int -> t
 val interval : int -> int -> t
+val mem : int -> t -> bool
 val to_seq : t -> int Seq.t

--- a/src/compiler/ir.ml
+++ b/src/compiler/ir.ml
@@ -82,7 +82,10 @@ let rep t n m =
   else (
     match reject_captures "Rep" t with
       | Error _ as e -> e
-      | Ok t -> Ok (Rep (t, n, m)))
+      (* [Rep (t, 1, 1)] is just [t]; normalize so single-character-length
+         checks (Compl/Sub/Intersect) still see the bare [Chars] node, as they
+         did on master where [repeat r (1, 1)] desugared to [r]. *)
+      | Ok t -> if n = 1 && m = 1 then Ok t else Ok (Rep (t, n, m)))
 
 let seq a b =
   let an = capture_names a in

--- a/src/compiler/ir.ml
+++ b/src/compiler/ir.ml
@@ -30,7 +30,14 @@ let reject_captures ctx t =
 (* Analysis *)
 
 let rec fixed_length = function
-  | Chars _ -> Some 1
+  | Chars c ->
+      (* [eof] (code point -1) is zero-width at runtime: [next] reports EOF
+         without advancing [pos]. A pure-eof cset is width 0; a cset mixing
+         eof with real characters has a data-dependent width (0 or 1), so its
+         length is unknown. *)
+      if Cset.mem (-1) c then
+        if Cset.is_empty (Cset.difference c Cset.eof) then Some 0 else None
+      else Some 1
   | Eps -> Some 0
   | Capture (_, inner) -> fixed_length inner
   | Seq elems ->

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -746,19 +746,12 @@ let rec lower ~left ~right (ir : Ir.t) : regexp * compiled_binding list =
         (* Sequence — propagate left/right position contexts through elements.
            Right positions are computed right-to-left; left positions are
            updated left-to-right after lowering each element. *)
-        let n = List.length elems in
-        let lengths = List.map Ir.fixed_length elems in
-        let lengths_arr = Array.of_list lengths in
-        (* Compute right positions (right-to-left) *)
-        let rights = Array.make n None in
-        let () =
-          let acc = ref right in
-          for i = n - 1 downto 0 do
-            rights.(i) <- !acc;
-            acc := retreat !acc lengths_arr.(i)
-          done
+        let _, rights =
+          List.fold_right
+            (fun e (acc, l) -> (retreat acc (Ir.fixed_length e), acc :: l))
+            elems (right, [])
         in
-        (* Fallback for [update_left]: if [advance] returns [None]
+        (* Fallback for the left context: if [advance] returns [None]
            (because the current left is unknown or the element has
            variable length), but the element was a [Capture] whose
            end position is a [Tag], we can use that tag as the [left]
@@ -774,25 +767,19 @@ let rec lower ~left ~right (ir : Ir.t) : regexp * compiled_binding list =
                   | _ -> None)
             | _ -> None
         in
-        let update_left cur i ir tags' =
-          match advance cur lengths_arr.(i) with
-            | Some _ as s -> s
-            | None -> left_from_end_tag ir tags'
-        in
-        let elems_arr = Array.of_list elems in
-        let r0, tags0 = lower ~left ~right:rights.(0) elems_arr.(0) in
-        let left0 = update_left left 0 elems_arr.(0) tags0 in
-        let _, _, r_acc, tags_acc =
-          Array.fold_left
-            (fun (i, cur_left, r_acc, tags_acc) ir_elem ->
-              if i = 0 then (1, left0, r_acc, tags_acc)
-              else (
-                let r', tags' =
-                  lower ~left:cur_left ~right:rights.(i) ir_elem
-                in
-                let new_left = update_left cur_left i ir_elem tags' in
-                (i + 1, new_left, seq r_acc r', tags_acc @ tags')))
-            (0, left, r0, tags0) elems_arr
+        (* [seq] is function composition and [eps] its identity, so the
+           fold needs no special case for the first element. *)
+        let _, r_acc, tags_acc =
+          List.fold_left2
+            (fun (cur_left, r_acc, tags_acc) e right ->
+              let r', tags' = lower ~left:cur_left ~right e in
+              let new_left =
+                match advance cur_left (Ir.fixed_length e) with
+                  | Some _ as s -> s
+                  | None -> left_from_end_tag e tags'
+              in
+              (new_left, seq r_acc r', tags_acc @ tags'))
+            (left, eps, []) elems rights
         in
         (r_acc, tags_acc)
 

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -321,7 +321,7 @@ let split_moves (moves : (Cset.t * config) list) : (Cset.t * config list) list =
 type dfa_state = {
   trans : (Cset.t * int * tag_op list) array;
   finals : bool array;
-  final_ops : tag_op list;
+  accept : (int * tag_op list) option;
 }
 
 type dfa = dfa_state array
@@ -551,26 +551,30 @@ let finals_of rs configs =
     (fun (_, fin) -> List.exists (fun ((n, _) : config) -> n == fin) configs)
     rs
 
-(* Materialize the accepting configuration's registers into the
+(* Materialize accepting rule [i]'s configuration registers into the
    canonical cells (cell = logical tag id) just before [mark]. Sources
    are working registers (>= num_logical) and destinations canonical
    cells, so the copies never interfere with each other. *)
-let final_ops_of regs rs configs finals =
+let final_ops_of regs rs configs i =
+  let _, fin = rs.(i) in
+  let _, m = List.find (fun ((n, _) : config) -> n == fin) configs in
+  TagMap.fold
+    (fun tag a acc ->
+      match a with
+        | Old c ->
+            if c = tag then acc
+            else (
+              assert (c >= regs.num_logical);
+              Copy { dst = tag; src = c } :: acc)
+        | New _ -> assert false)
+    m []
+
+(* Resolve rule priority: the accepting state carries the lowest-numbered
+   (highest-priority) matching rule and the ops materializing its registers. *)
+let accept_of regs rs configs finals =
   match lowest_final finals with
-    | None -> []
-    | Some i ->
-        let _, fin = rs.(i) in
-        let _, m = List.find (fun ((n, _) : config) -> n == fin) configs in
-        TagMap.fold
-          (fun tag a acc ->
-            match a with
-              | Old c ->
-                  if c = tag then acc
-                  else (
-                    assert (c >= regs.num_logical);
-                    Copy { dst = tag; src = c } :: acc)
-              | New _ -> assert false)
-          m []
+    | None -> None
+    | Some i -> Some (i, final_ops_of regs rs configs i)
 
 (* Rename pass: a conflict-free tag only ever needs one register at a
    time, so its whole pool collapses into its canonical cell — writes go
@@ -632,8 +636,8 @@ let compile rs =
     let configs = Hashtbl.find tbl.configs num in
     let trans = transition regs tbl configs in
     let finals = finals_of rs configs in
-    let final_ops = final_ops_of regs rs configs finals in
-    Hashtbl.add defs num { trans; finals; final_ops }
+    let accept = accept_of regs rs configs finals in
+    Hashtbl.add defs num { trans; finals; accept }
   done;
   let cell_map, num_tags = collapse_conflict_free regs in
   let dfa =
@@ -645,7 +649,10 @@ let compile rs =
             Array.map
               (fun (c, t, ops) -> (c, t, rewrite_ops cell_map ops))
               s.trans;
-          final_ops = rewrite_ops cell_map s.final_ops;
+          accept =
+            Option.map
+              (fun (i, ops) -> (i, rewrite_ops cell_map ops))
+              s.accept;
         })
   in
   { dfa; init_tags = rewrite_ops cell_map init_tags; num_tags }
@@ -898,7 +905,7 @@ let dfa_to_dot dfa =
     | Copy { dst; src } -> "t" ^ string_of_int dst ^ "<-t" ^ string_of_int src
   in
   Array.iteri
-    (fun i { trans; finals; final_ops } ->
+    (fun i { trans; finals; accept } ->
       let accepted =
         let acc = ref [] in
         for r = Array.length finals - 1 downto 0 do
@@ -909,6 +916,9 @@ let dfa_to_dot dfa =
       (match accepted with
         | [] -> bprintf buf "  state%d [label=\"%d\"];\n" i i
         | rules ->
+            let final_ops =
+              match accept with Some (_, ops) -> ops | None -> []
+            in
             let ops =
               if final_ops = [] then ""
               else

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -332,263 +332,312 @@ type compiled = { dfa : dfa; init_tags : tag_op list; num_tags : int }
 let op_dest = function
   | Copy { dst; _ } | Set_position { dst } | Set_value { dst; _ } -> dst
 
-(* [compile rs] determinizes the NFA for an array of regexp rules. See the
-   implementation overview at the top of this file. *)
-let compile rs =
-  let rs = Array.map compile_re rs in
-  let num_logical = !cur_tag in
-  (* Working registers live above the canonical cells 0..num_logical-1,
-     which are written only by [final_ops] and read by the generated
-     binding-extraction code. *)
-  let next_cell = ref num_logical in
-  (* Per-logical-tag pool of working registers allocated so far; reusing
-     them keeps the total cell count small. Pools of distinct tags are
-     disjoint. *)
-  let pools : (int, int list) Hashtbl.t = Hashtbl.create 8 in
-  let alloc_cell used tag =
-    let pool =
-      match Hashtbl.find_opt pools tag with Some l -> l | None -> []
-    in
-    match List.find_opt (fun c -> not (List.mem c !used)) pool with
-      | Some c ->
-          used := c :: !used;
-          c
+(* === Determinization state ===
+
+   The subset construction threads two pieces of mutable state, made
+   explicit as records: [registers] (memory-cell allocation) and
+   [state_table] (the DFA states discovered so far). *)
+
+(* Memory-cell allocation state. *)
+type registers = {
+  num_logical : int;
+      (* Number of logical tags. Canonical cells 0..num_logical-1 are
+         written only by [final_ops] and read by the generated
+         binding-extraction code; working registers live above them. *)
+  mutable next_cell : int; (* Next fresh working register. *)
+  pools : (int, int list) Hashtbl.t;
+      (* Per-logical-tag pool of working registers allocated so far;
+         reusing them keeps the total cell count small. Pools of distinct
+         tags are disjoint. *)
+  conflicted : (int, unit) Hashtbl.t;
+      (* Tags seen holding two distinct registers in one DFA state. *)
+}
+
+let make_registers num_logical =
+  {
+    num_logical;
+    next_cell = num_logical;
+    pools = Hashtbl.create 8;
+    conflicted = Hashtbl.create 8;
+  }
+
+(* [alloc_cell regs used tag] picks a working register for [tag],
+   preferring a register from the tag's pool not already in [used]. *)
+let alloc_cell regs used tag =
+  let pool =
+    match Hashtbl.find_opt regs.pools tag with Some l -> l | None -> []
+  in
+  match List.find_opt (fun c -> not (List.mem c !used)) pool with
+    | Some c ->
+        used := c :: !used;
+        c
+    | None ->
+        let c = regs.next_cell in
+        regs.next_cell <- regs.next_cell + 1;
+        Hashtbl.replace regs.pools tag (c :: pool);
+        used := c :: !used;
+        c
+
+(* [check_conflicts regs configs] records in [regs.conflicted] every tag
+   for which [configs] holds two distinct registers — i.e. two
+   simultaneously-live NFA paths recorded different values. Conflict-free
+   tags can live directly in their canonical cell (see
+   [collapse_conflict_free]). Checking candidates is enough: a stored
+   state has the same canonical key, hence the same sharing structure. *)
+let check_conflicts regs configs =
+  let seen = Hashtbl.create 8 in
+  List.iter
+    (fun ((_, m) : config) ->
+      IntMap.iter
+        (fun tag a ->
+          match Hashtbl.find_opt seen tag with
+            | None -> Hashtbl.add seen tag a
+            | Some a' -> if a <> a' then Hashtbl.replace regs.conflicted tag ())
+        m)
+    configs
+
+(* DFA states are looked up modulo bijective register renaming: the key
+   numbers each distinct address by first occurrence, so two states with
+   the same node order and the same register-sharing structure collide. *)
+type state_key = (int * (int * int) list) list
+
+let state_key (configs : config list) : state_key =
+  let tbl = Hashtbl.create 8 in
+  let canon a =
+    match Hashtbl.find_opt tbl a with
+      | Some i -> i
       | None ->
-          let c = !next_cell in
-          incr next_cell;
-          Hashtbl.replace pools tag (c :: pool);
-          used := c :: !used;
+          let i = Hashtbl.length tbl in
+          Hashtbl.add tbl a i;
+          i
+  in
+  List.map
+    (fun (n, m) ->
+      (n.id, List.map (fun (t, a) -> (t, canon a)) (IntMap.bindings m)))
+    configs
+
+(* DFA states discovered so far, numbered in creation order. *)
+type state_table = {
+  by_key : (state_key, int) Hashtbl.t;
+  configs : (int, config list) Hashtbl.t;
+      (* Stored configurations; all addresses are [Old]. *)
+  defs : (int, dfa_state) Hashtbl.t; (* Filled by the main loop. *)
+  mutable n_states : int;
+  todo : int Queue.t; (* States whose transitions are not yet built. *)
+}
+
+let make_state_table () =
+  {
+    by_key = Hashtbl.create 31;
+    configs = Hashtbl.create 31;
+    defs = Hashtbl.create 31;
+    n_states = 0;
+    todo = Queue.create ();
+  }
+
+(* Creating a new state: [Old] registers are kept as-is, [New] writes get
+   concrete cells; the transition only carries the Set operations. *)
+let concretize regs configs new_writes =
+  let used =
+    ref
+      (List.concat_map
+         (fun ((_, m) : config) ->
+           List.filter_map
+             (fun (_, a) -> match a with Old c -> Some c | New _ -> None)
+             (IntMap.bindings m))
+         configs)
+  in
+  let assigned = Hashtbl.create 4 in
+  let ops = ref [] in
+  let cell_for_new tag i =
+    match Hashtbl.find_opt assigned i with
+      | Some c -> c
+      | None ->
+          let c = alloc_cell regs used tag in
+          Hashtbl.add assigned i c;
+          (match List.assoc i new_writes with
+            | Wpos -> ops := Set_position { dst = c } :: !ops
+            | Wval v -> ops := Set_value { dst = c; value = v } :: !ops);
           c
   in
-  (* DFA states are looked up modulo bijective register renaming: the key
-     numbers each distinct address by first occurrence, so two states with
-     the same node order and the same register-sharing structure collide. *)
-  let state_key (configs : config list) =
-    let tbl = Hashtbl.create 8 in
-    let canon a =
-      match Hashtbl.find_opt tbl a with
-        | Some i -> i
-        | None ->
-            let i = Hashtbl.length tbl in
-            Hashtbl.add tbl a i;
-            i
-    in
+  let configs =
     List.map
       (fun (n, m) ->
-        (n.id, List.map (fun (t, a) -> (t, canon a)) (IntMap.bindings m)))
+        ( n,
+          IntMap.mapi
+            (fun tag a ->
+              match a with Old _ -> a | New i -> Old (cell_for_new tag i))
+            m ))
       configs
   in
-  let states = Hashtbl.create 31 in
-  let state_configs : (int, config list) Hashtbl.t = Hashtbl.create 31 in
-  let states_def = Hashtbl.create 31 in
-  let counter = ref 0 in
-  let todo = Queue.create () in
-  (* Creating a new state: [Old] registers are kept as-is, [New] writes get
-     concrete cells; the transition only carries the Set operations. *)
-  let concretize configs new_writes =
-    let used =
-      ref
-        (List.concat_map
-           (fun ((_, m) : config) ->
-             List.filter_map
-               (fun (_, a) -> match a with Old c -> Some c | New _ -> None)
-               (IntMap.bindings m))
-           configs)
-    in
-    let assigned = Hashtbl.create 4 in
-    let ops = ref [] in
-    let cell_for_new tag i =
-      match Hashtbl.find_opt assigned i with
-        | Some c -> c
-        | None ->
-            let c = alloc_cell used tag in
-            Hashtbl.add assigned i c;
-            (match List.assoc i new_writes with
-              | Wpos -> ops := Set_position { dst = c } :: !ops
-              | Wval v -> ops := Set_value { dst = c; value = v } :: !ops);
-            c
-    in
-    let configs =
-      List.map
-        (fun (n, m) ->
-          ( n,
-            IntMap.mapi
-              (fun tag a ->
-                match a with Old _ -> a | New i -> Old (cell_for_new tag i))
-              m ))
-        configs
-    in
-    (configs, !ops)
+  (configs, !ops)
+
+(* Reaching an existing state: emit the register moves that realign the
+   candidate's registers with the stored state's maps. Equal canonical
+   keys guarantee each destination cell gets a single consistent move.
+   The result is a parallel move (Copy sources observe the pre-transition
+   state); it is sorted by destination only for output stability. *)
+let moves_to candidate new_writes existing =
+  let moves = Hashtbl.create 8 in
+  List.iter2
+    (fun ((_, m_cand) : config) ((_, m_ex) : config) ->
+      IntMap.iter
+        (fun tag a ->
+          let dst =
+            match IntMap.find tag m_ex with Old c -> c | New _ -> assert false
+          in
+          match a with
+            | Old src ->
+                if src <> dst then Hashtbl.replace moves dst (Copy { dst; src })
+            | New i -> (
+                match List.assoc i new_writes with
+                  | Wpos -> Hashtbl.replace moves dst (Set_position { dst })
+                  | Wval v ->
+                      Hashtbl.replace moves dst (Set_value { dst; value = v })))
+        m_cand)
+    candidate existing;
+  let mvs = Hashtbl.fold (fun _ op acc -> op :: acc) moves [] in
+  List.sort (fun a b -> compare (op_dest a) (op_dest b)) mvs
+
+(* [get_state regs tbl candidate new_writes] returns the state number for
+   [candidate], creating and enqueuing it if new, plus the tag operations
+   the transition reaching it must perform. *)
+let get_state regs tbl candidate new_writes =
+  check_conflicts regs candidate;
+  let key = state_key candidate in
+  match Hashtbl.find_opt tbl.by_key key with
+    | Some num ->
+        (num, moves_to candidate new_writes (Hashtbl.find tbl.configs num))
+    | None ->
+        let configs, ops = concretize regs candidate new_writes in
+        let num = tbl.n_states in
+        tbl.n_states <- num + 1;
+        Hashtbl.add tbl.by_key key num;
+        Hashtbl.add tbl.configs num configs;
+        Queue.push num tbl.todo;
+        (num, ops)
+
+(* [transition regs tbl configs] builds the outgoing transitions of one
+   DFA state: collect the character moves of every configuration, split
+   them into pairwise-disjoint sets, then close over and look up each
+   piece. *)
+let transition regs tbl configs =
+  let moves =
+    List.concat_map
+      (fun ((n, m) : config) -> List.map (fun (c, n') -> (c, (n', m))) n.trans)
+      configs
   in
-  (* Reaching an existing state: emit the register moves that realign the
-     candidate's registers with the stored state's maps. Equal canonical
-     keys guarantee each destination cell gets a single consistent move.
-     The result is a parallel move (Copy sources observe the pre-transition
-     state); it is sorted by destination only for output stability. *)
-  let moves_to candidate new_writes existing =
-    let moves = Hashtbl.create 8 in
-    List.iter2
-      (fun ((_, m_cand) : config) ((_, m_ex) : config) ->
-        IntMap.iter
-          (fun tag a ->
-            let dst =
-              match IntMap.find tag m_ex with
-                | Old c -> c
-                | New _ -> assert false
-            in
+  let pieces = split_moves moves in
+  let t =
+    List.map
+      (fun (cset, seeds) ->
+        let candidate, new_writes = closure seeds in
+        let num, ops = get_state regs tbl candidate new_writes in
+        (cset, num, ops))
+      pieces
+  in
+  let t = Array.of_list t in
+  Array.sort (fun (c1, _, _) (c2, _, _) -> compare c1 c2) t;
+  t
+
+let lowest_final finals =
+  let n = Array.length finals in
+  let rec aux i =
+    if i = n then None else if finals.(i) then Some i else aux (i + 1)
+  in
+  aux 0
+
+let finals_of rs configs =
+  Array.map
+    (fun (_, fin) -> List.exists (fun ((n, _) : config) -> n == fin) configs)
+    rs
+
+(* Materialize the accepting configuration's registers into the
+   canonical cells (cell = logical tag id) just before [mark]. Sources
+   are working registers (>= num_logical) and destinations canonical
+   cells, so the copies never interfere with each other. *)
+let final_ops_of rs configs finals =
+  match lowest_final finals with
+    | None -> []
+    | Some i ->
+        let _, fin = rs.(i) in
+        let _, m = List.find (fun ((n, _) : config) -> n == fin) configs in
+        IntMap.fold
+          (fun tag a acc ->
             match a with
-              | Old src ->
-                  if src <> dst then
-                    Hashtbl.replace moves dst (Copy { dst; src })
-              | New i -> (
-                  match List.assoc i new_writes with
-                    | Wpos -> Hashtbl.replace moves dst (Set_position { dst })
-                    | Wval v ->
-                        Hashtbl.replace moves dst (Set_value { dst; value = v })
-                  ))
-          m_cand)
-      candidate existing;
-    let mvs = Hashtbl.fold (fun _ op acc -> op :: acc) moves [] in
-    List.sort (fun a b -> compare (op_dest a) (op_dest b)) mvs
-  in
-  (* A tag is conflicted when some DFA state holds two distinct registers
-     for it — i.e. two simultaneously-live NFA paths recorded different
-     values. Conflict-free tags can live directly in their canonical cell
-     (see the rename pass below). Checking candidates is enough: a stored
-     state has the same canonical key, hence the same sharing structure. *)
-  let conflicted = Hashtbl.create 8 in
-  let check_conflicts configs =
-    let seen = Hashtbl.create 8 in
-    List.iter
-      (fun ((_, m) : config) ->
-        IntMap.iter
-          (fun tag a ->
-            match Hashtbl.find_opt seen tag with
-              | None -> Hashtbl.add seen tag a
-              | Some a' -> if a <> a' then Hashtbl.replace conflicted tag ())
-          m)
-      configs
-  in
-  let get_state candidate new_writes =
-    check_conflicts candidate;
-    let key = state_key candidate in
-    match Hashtbl.find_opt states key with
-      | Some num ->
-          (num, moves_to candidate new_writes (Hashtbl.find state_configs num))
-      | None ->
-          let configs, ops = concretize candidate new_writes in
-          let num = !counter in
-          incr counter;
-          Hashtbl.add states key num;
-          Hashtbl.add state_configs num configs;
-          Queue.push num todo;
-          (num, ops)
-  in
-  let transition configs =
-    let moves =
-      List.concat_map
-        (fun ((n, m) : config) ->
-          List.map (fun (c, n') -> (c, (n', m))) n.trans)
-        configs
-    in
-    let pieces = split_moves moves in
-    let t =
-      List.map
-        (fun (cset, seeds) ->
-          let candidate, new_writes = closure seeds in
-          let num, ops = get_state candidate new_writes in
-          (cset, num, ops))
-        pieces
-    in
-    let t = Array.of_list t in
-    Array.sort (fun (c1, _, _) (c2, _, _) -> compare c1 c2) t;
-    t
-  in
-  let lowest_final finals =
-    let n = Array.length finals in
-    let rec aux i =
-      if i = n then None else if finals.(i) then Some i else aux (i + 1)
-    in
-    aux 0
-  in
-  let finals_of configs =
-    Array.map
-      (fun (_, fin) -> List.exists (fun ((n, _) : config) -> n == fin) configs)
-      rs
-  in
-  (* Materialize the accepting configuration's registers into the
-     canonical cells (cell = logical tag id) just before [mark]. Sources
-     are working registers (>= num_logical) and destinations canonical
-     cells, so the copies never interfere with each other. *)
-  let final_ops_of configs finals =
-    match lowest_final finals with
-      | None -> []
-      | Some i ->
-          let _, fin = rs.(i) in
-          let _, m = List.find (fun ((n, _) : config) -> n == fin) configs in
-          IntMap.fold
-            (fun tag a acc ->
-              match a with
-                | Old c ->
-                    if c = tag then acc else Copy { dst = tag; src = c } :: acc
-                | New _ -> assert false)
-            m []
-  in
-  let init_candidate, init_writes =
-    closure
-      (List.map (fun (entry, _) -> (entry, IntMap.empty)) (Array.to_list rs))
-  in
-  let num0, init_tags = get_state init_candidate init_writes in
-  assert (num0 = 0);
-  while not (Queue.is_empty todo) do
-    let num = Queue.pop todo in
-    let configs = Hashtbl.find state_configs num in
-    let trans = transition configs in
-    let finals = finals_of configs in
-    let final_ops = final_ops_of configs finals in
-    Hashtbl.add states_def num { trans; finals; final_ops }
-  done;
-  (* Rename pass: a conflict-free tag only ever needs one register at a
-     time, so its whole pool collapses into its canonical cell — writes go
-     there directly, and the realignment / materialization copies become
-     no-op Copy(t, t) and are dropped. Register pools are per-tag, so the
-     rename cannot collide with another tag's cells. The surviving working
-     registers (conflicted tags) are compacted just above the canonical
-     cells. *)
-  let cell_map = Array.init !next_cell (fun c -> c) in
+              | Old c ->
+                  if c = tag then acc else Copy { dst = tag; src = c } :: acc
+              | New _ -> assert false)
+          m []
+
+(* Rename pass: a conflict-free tag only ever needs one register at a
+   time, so its whole pool collapses into its canonical cell — writes go
+   there directly, and the realignment / materialization copies become
+   no-op Copy(t, t) and are dropped. Register pools are per-tag, so the
+   rename cannot collide with another tag's cells. The surviving working
+   registers (conflicted tags) are compacted just above the canonical
+   cells. Returns the cell renaming and the total cell count after it. *)
+let collapse_conflict_free regs =
+  let cell_map = Array.init regs.next_cell (fun c -> c) in
   Hashtbl.iter
     (fun tag pool ->
-      if not (Hashtbl.mem conflicted tag) then
+      if not (Hashtbl.mem regs.conflicted tag) then
         List.iter (fun c -> cell_map.(c) <- tag) pool)
-    pools;
-  let compact = ref num_logical in
-  for c = num_logical to !next_cell - 1 do
+    regs.pools;
+  let compact = ref regs.num_logical in
+  for c = regs.num_logical to regs.next_cell - 1 do
     if cell_map.(c) = c then (
       cell_map.(c) <- !compact;
       incr compact)
   done;
-  let rewrite_ops ops =
-    List.filter_map
-      (fun op ->
-        match op with
-          | Set_position { dst } -> Some (Set_position { dst = cell_map.(dst) })
-          | Set_value { dst; value } ->
-              Some (Set_value { dst = cell_map.(dst); value })
-          | Copy { dst; src } ->
-              let dst = cell_map.(dst) and src = cell_map.(src) in
-              if dst = src then None else Some (Copy { dst; src }))
-      ops
+  (cell_map, !compact)
+
+let rewrite_ops cell_map ops =
+  List.filter_map
+    (fun op ->
+      match op with
+        | Set_position { dst } -> Some (Set_position { dst = cell_map.(dst) })
+        | Set_value { dst; value } ->
+            Some (Set_value { dst = cell_map.(dst); value })
+        | Copy { dst; src } ->
+            let dst = cell_map.(dst) and src = cell_map.(src) in
+            if dst = src then None else Some (Copy { dst; src }))
+    ops
+
+(* [compile rs] determinizes the NFA for an array of regexp rules. See the
+   implementation overview at the top of this file. *)
+let compile rs =
+  let rs = Array.map compile_re rs in
+  let regs = make_registers !cur_tag in
+  let tbl = make_state_table () in
+  let init_candidate, init_writes =
+    closure
+      (List.map (fun (entry, _) -> (entry, IntMap.empty)) (Array.to_list rs))
   in
+  let num0, init_tags = get_state regs tbl init_candidate init_writes in
+  assert (num0 = 0);
+  while not (Queue.is_empty tbl.todo) do
+    let num = Queue.pop tbl.todo in
+    let configs = Hashtbl.find tbl.configs num in
+    let trans = transition regs tbl configs in
+    let finals = finals_of rs configs in
+    let final_ops = final_ops_of rs configs finals in
+    Hashtbl.add tbl.defs num { trans; finals; final_ops }
+  done;
+  let cell_map, num_tags = collapse_conflict_free regs in
   let dfa =
-    Array.init !counter (fun i ->
-        let s = Hashtbl.find states_def i in
+    Array.init tbl.n_states (fun i ->
+        let s = Hashtbl.find tbl.defs i in
         {
           s with
-          trans = Array.map (fun (c, t, ops) -> (c, t, rewrite_ops ops)) s.trans;
-          final_ops = rewrite_ops s.final_ops;
+          trans =
+            Array.map
+              (fun (c, t, ops) -> (c, t, rewrite_ops cell_map ops))
+              s.trans;
+          final_ops = rewrite_ops cell_map s.final_ops;
         })
   in
-  { dfa; init_tags = rewrite_ops init_tags; num_tags = !compact }
+  { dfa; init_tags = rewrite_ops cell_map init_tags; num_tags }
 
 (* High-level compilation from IR.
 

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -477,6 +477,11 @@ let concretize regs configs new_writes =
    state); it is sorted by destination only for output stability. *)
 let moves_to candidate new_writes existing =
   let moves = Hashtbl.create 8 in
+  let set_move dst op =
+    match Hashtbl.find_opt moves dst with
+      | None -> Hashtbl.add moves dst op
+      | Some op' -> assert (op = op')
+  in
   List.iter2
     (fun ((_, m_cand) : config) ((_, m_ex) : config) ->
       IntMap.iter
@@ -485,13 +490,11 @@ let moves_to candidate new_writes existing =
             match IntMap.find tag m_ex with Old c -> c | New _ -> assert false
           in
           match a with
-            | Old src ->
-                if src <> dst then Hashtbl.replace moves dst (Copy { dst; src })
+            | Old src -> if src <> dst then set_move dst (Copy { dst; src })
             | New i -> (
                 match List.assoc i new_writes with
-                  | Wpos -> Hashtbl.replace moves dst (Set_position { dst })
-                  | Wval v ->
-                      Hashtbl.replace moves dst (Set_value { dst; value = v })))
+                  | Wpos -> set_move dst (Set_position { dst })
+                  | Wval v -> set_move dst (Set_value { dst; value = v })))
         m_cand)
     candidate existing;
   let mvs = Hashtbl.fold (fun _ op acc -> op :: acc) moves [] in
@@ -554,7 +557,7 @@ let finals_of rs configs =
    canonical cells (cell = logical tag id) just before [mark]. Sources
    are working registers (>= num_logical) and destinations canonical
    cells, so the copies never interfere with each other. *)
-let final_ops_of rs configs finals =
+let final_ops_of regs rs configs finals =
   match lowest_final finals with
     | None -> []
     | Some i ->
@@ -564,7 +567,10 @@ let final_ops_of rs configs finals =
           (fun tag a acc ->
             match a with
               | Old c ->
-                  if c = tag then acc else Copy { dst = tag; src = c } :: acc
+                  if c = tag then acc
+                  else (
+                    assert (c >= regs.num_logical);
+                    Copy { dst = tag; src = c } :: acc)
               | New _ -> assert false)
           m []
 
@@ -591,16 +597,24 @@ let collapse_conflict_free regs =
   (cell_map, !compact)
 
 let rewrite_ops cell_map ops =
-  List.filter_map
-    (fun op ->
-      match op with
-        | Set_position { dst } -> Some (Set_position { dst = cell_map.(dst) })
-        | Set_value { dst; value } ->
-            Some (Set_value { dst = cell_map.(dst); value })
-        | Copy { dst; src } ->
-            let dst = cell_map.(dst) and src = cell_map.(src) in
-            if dst = src then None else Some (Copy { dst; src }))
-    ops
+  let ops =
+    List.filter_map
+      (fun op ->
+        match op with
+          | Set_position { dst } -> Some (Set_position { dst = cell_map.(dst) })
+          | Set_value { dst; value } ->
+              Some (Set_value { dst = cell_map.(dst); value })
+          | Copy { dst; src } ->
+              let dst = cell_map.(dst) and src = cell_map.(src) in
+              if dst = src then None else Some (Copy { dst; src }))
+      ops
+  in
+  (* The renaming must preserve the parallel-move property: no two
+     operations of one list write the same cell (the generated code relies
+     on this when saving clobbered Copy sources). *)
+  let dsts = List.map op_dest ops in
+  assert (List.length (List.sort_uniq compare dsts) = List.length dsts);
+  ops
 
 (* [compile rs] determinizes the NFA for an array of regexp rules. See the
    implementation overview at the top of this file. *)
@@ -620,7 +634,7 @@ let compile rs =
     let configs = Hashtbl.find tbl.configs num in
     let trans = transition regs tbl configs in
     let finals = finals_of rs configs in
-    let final_ops = final_ops_of rs configs finals in
+    let final_ops = final_ops_of regs rs configs finals in
     Hashtbl.add defs num { trans; finals; final_ops }
   done;
   let cell_map, num_tags = collapse_conflict_free regs in

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -64,6 +64,13 @@
       run just before [Sedlexing.mark], so the snapshot/backtrack machinery
       needs no changes.
 
+      A final rename pass collapses the registers of conflict-free tags —
+      tags that never hold two distinct registers in one state — into
+      their canonical cell, dropping the no-op copies this creates. Only
+      genuinely conflicted tags (e.g. a capture start reachable from a
+      preceding loop's closure, or a discriminator written by two branches
+      that stay alive together) pay for extra working registers.
+
    Possible future optimizations (see #175)
    -----------------------------------------
 
@@ -279,7 +286,12 @@ let closure (seeds : config list) =
               IntMap.add cell (New (new_id (`Val (cell, v)) (Wval v))) m
           | Some (Copy _) -> assert false (* never carried by NFA nodes *)
       in
-      acc := (n, m) :: !acc;
+      (* Keep only configurations that matter: nodes with outgoing char
+         transitions, and rule-final nodes (no transitions, no epsilon
+         successors). Epsilon-only nodes contribute nothing once visited —
+         keeping them would bloat state keys and flag spurious tag
+         conflicts (e.g. the losing branch's discriminator node). *)
+      if n.trans <> [] || n.eps = [] then acc := (n, m) :: !acc;
       List.iter (fun n' -> visit (n', m)) n.eps)
   in
   List.iter visit seeds;
@@ -439,7 +451,26 @@ let compile rs =
     let mvs = Hashtbl.fold (fun _ op acc -> op :: acc) moves [] in
     List.sort (fun a b -> compare (op_dest a) (op_dest b)) mvs
   in
+  (* A tag is conflicted when some DFA state holds two distinct registers
+     for it — i.e. two simultaneously-live NFA paths recorded different
+     values. Conflict-free tags can live directly in their canonical cell
+     (see the rename pass below). Checking candidates is enough: a stored
+     state has the same canonical key, hence the same sharing structure. *)
+  let conflicted = Hashtbl.create 8 in
+  let check_conflicts configs =
+    let seen = Hashtbl.create 8 in
+    List.iter
+      (fun ((_, m) : config) ->
+        IntMap.iter
+          (fun tag a ->
+            match Hashtbl.find_opt seen tag with
+              | None -> Hashtbl.add seen tag a
+              | Some a' -> if a <> a' then Hashtbl.replace conflicted tag ())
+          m)
+      configs
+  in
   let get_state candidate new_writes =
+    check_conflicts candidate;
     let key = state_key candidate in
     match Hashtbl.find_opt states key with
       | Some num ->
@@ -518,11 +549,46 @@ let compile rs =
     let final_ops = final_ops_of configs finals in
     Hashtbl.add states_def num { trans; finals; final_ops }
   done;
-  {
-    dfa = Array.init !counter (Hashtbl.find states_def);
-    init_tags;
-    num_tags = !next_cell;
-  }
+  (* Rename pass: a conflict-free tag only ever needs one register at a
+     time, so its whole pool collapses into its canonical cell — writes go
+     there directly, and the realignment / materialization copies become
+     no-op Copy(t, t) and are dropped. Register pools are per-tag, so the
+     rename cannot collide with another tag's cells. The surviving working
+     registers (conflicted tags) are compacted just above the canonical
+     cells. *)
+  let cell_map = Array.init !next_cell (fun c -> c) in
+  Hashtbl.iter
+    (fun tag pool ->
+      if not (Hashtbl.mem conflicted tag) then
+        List.iter (fun c -> cell_map.(c) <- tag) pool)
+    pools;
+  let compact = ref num_logical in
+  for c = num_logical to !next_cell - 1 do
+    if cell_map.(c) = c then (
+      cell_map.(c) <- !compact;
+      incr compact)
+  done;
+  let rewrite_ops ops =
+    List.filter_map
+      (fun op ->
+        match op with
+          | Set_position d -> Some (Set_position cell_map.(d))
+          | Set_value (d, v) -> Some (Set_value (cell_map.(d), v))
+          | Copy (d, s) ->
+              let d = cell_map.(d) and s = cell_map.(s) in
+              if d = s then None else Some (Copy (d, s)))
+      ops
+  in
+  let dfa =
+    Array.init !counter (fun i ->
+        let s = Hashtbl.find states_def i in
+        {
+          s with
+          trans = Array.map (fun (c, t, ops) -> (c, t, rewrite_ops ops)) s.trans;
+          final_ops = rewrite_ops s.final_ops;
+        })
+  in
+  { dfa; init_tags = rewrite_ops init_tags; num_tags = !compact }
 
 (* High-level compilation from IR.
 

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -51,8 +51,12 @@
       registers (the canonical key numbers registers by first occurrence).
       When the lookup hits an existing state, register-move operations
       (Copy/Set) are emitted on the transition to realign registers with
-      the existing state's maps; moves are topologically sorted, breaking
-      cycles with a temporary cell.
+      the existing state's maps. The operations of one transition form a
+      parallel move: every Copy reads its source as it was before the
+      transition's writes. The code generator implements this by saving
+      clobbered sources in let-bound locals, so no move ordering or
+      temporary cells are needed (ocamllex needs both because its moves
+      are interpreted by a fixed C engine with no scratch locals).
 
       Accepting states carry [final_ops]: Copy operations that materialize
       the accepting configuration's registers into the canonical cells
@@ -316,7 +320,6 @@ type dfa = dfa_state array
 type compiled = { dfa : dfa; init_tags : tag_op list; num_tags : int }
 
 let op_dest = function Copy (d, _) | Set_position d | Set_value (d, _) -> d
-let op_orig = function Copy (_, s) -> s | Set_position _ | Set_value _ -> -1
 
 (* [compile rs] determinizes the NFA for an array of regexp rules. See the
    implementation overview at the top of this file. *)
@@ -331,24 +334,6 @@ let compile rs =
      them keeps the total cell count small. Pools of distinct tags are
      disjoint. *)
   let pools : (int, int list) Hashtbl.t = Hashtbl.create 8 in
-  (* Temporary cells used to break cycles in register moves. The pool is
-     shared between transitions, but within one move set each cycle gets a
-     distinct temp (two independent cycles must not clobber each other's
-     saved value). *)
-  let temps = ref [] in
-  let fresh_temps () =
-    let avail = ref !temps in
-    fun () ->
-      match !avail with
-        | c :: rest ->
-            avail := rest;
-            c
-        | [] ->
-            let c = !next_cell in
-            incr next_cell;
-            temps := !temps @ [c];
-            c
-  in
   let alloc_cell used tag =
     let pool =
       match Hashtbl.find_opt pools tag with Some l -> l | None -> []
@@ -363,37 +348,6 @@ let compile rs =
           Hashtbl.replace pools tag (c :: pool);
           used := c :: !used;
           c
-  in
-  (* Topological sort of register moves: a move whose source is the
-     destination of another pending move must run first; cycles are broken
-     through a temporary cell (ocamllex's sort_mvs). The result list is in
-     execution order. *)
-  let sort_mvs mvs =
-    let alloc_temp = fresh_temps () in
-    let rec go sorted mvs =
-      match mvs with
-        | [] -> sorted
-        | _ -> (
-            let dests = List.map op_dest mvs in
-            let rem, here =
-              List.partition (fun mv -> List.mem (op_orig mv) dests) mvs
-            in
-            match here with
-              | [] -> (
-                  match rem with
-                    | Copy (d, _) :: _ ->
-                        let t = alloc_temp () in
-                        Copy (t, d)
-                        :: go sorted
-                             (List.map
-                                (fun mv ->
-                                  if op_orig mv = d then Copy (op_dest mv, t)
-                                  else mv)
-                                rem)
-                    | _ -> assert false)
-              | _ -> go (here @ sorted) rem)
-    in
-    go [] mvs
   in
   (* DFA states are looked up modulo bijective register renaming: the key
      numbers each distinct address by first occurrence, so two states with
@@ -459,7 +413,9 @@ let compile rs =
   in
   (* Reaching an existing state: emit the register moves that realign the
      candidate's registers with the stored state's maps. Equal canonical
-     keys guarantee each destination cell gets a single consistent move. *)
+     keys guarantee each destination cell gets a single consistent move.
+     The result is a parallel move (Copy sources observe the pre-transition
+     state); it is sorted by destination only for output stability. *)
   let moves_to candidate new_writes existing =
     let moves = Hashtbl.create 8 in
     List.iter2
@@ -481,8 +437,7 @@ let compile rs =
           m_cand)
       candidate existing;
     let mvs = Hashtbl.fold (fun _ op acc -> op :: acc) moves [] in
-    let mvs = List.sort (fun a b -> compare (op_dest a) (op_dest b)) mvs in
-    sort_mvs mvs
+    List.sort (fun a b -> compare (op_dest a) (op_dest b)) mvs
   in
   let get_state candidate new_writes =
     let key = state_key candidate in

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -74,7 +74,10 @@ module Cset = Cset
 
 (* NFA *)
 
-type tag_op = Set_position of int | Set_value of int * int
+type tag_op =
+  | Set_position of int
+  | Set_value of int * int
+  | Copy of int * int
 
 type node = {
   id : int;  (** Unique identifier, used for sorting transitions by target. *)
@@ -246,12 +249,12 @@ let dedup_tags tags =
           match Hashtbl.find_opt dominated cell with
             | Some v when v <= value -> ()
             | _ -> Hashtbl.replace dominated cell value)
-      | Set_position _ -> ())
+      | Set_position _ | Copy _ -> ())
     tags;
   List.filter
     (function
       | Set_value (cell, value) -> Hashtbl.find dominated cell = value
-      | Set_position _ -> true)
+      | Set_position _ | Copy _ -> true)
     tags
 
 (* [transition state] computes all outgoing DFA transitions from a DFA state.
@@ -616,6 +619,8 @@ let dfa_to_dot dfa =
           let tag_op_to_string = function
             | Set_position t -> "t" ^ string_of_int t
             | Set_value (c, v) -> "d" ^ string_of_int c ^ "=" ^ string_of_int v
+            | Copy (dst, src) ->
+                "t" ^ string_of_int dst ^ "<-t" ^ string_of_int src
           in
           let label =
             if tags = [] then label

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -25,46 +25,47 @@
       or-patterns where multiple branches bind the same name.
 
    3. Determinization (compile)
-      Classic subset construction, extended to handle tags (Laurikari, NFAs
-      with Tagged Transitions, 2000).
+      Subset construction extended to tagged NFAs (Laurikari, "NFAs with
+      Tagged Transitions", 2000), following the structure of ocamllex's
+      implementation (lex/lexgen.ml in the OCaml distribution).
 
-      Each DFA state is a set of NFA nodes (represented as a list, identified
-      by physical identity via memq). DFA states are memoized in a hash table
-      keyed by node lists.
+      A DFA state is an ordered list of configurations: (NFA node, register
+      map). The register map records, per logical tag, which memory cell
+      holds that tag's position *along the NFA path that reached this node*.
+      Keeping one map per configuration — instead of one shared vector — is
+      what makes captures correct when a tagged epsilon node is reachable
+      from several paths at once (e.g. a Star loop whose epsilon closure
+      contains the start node of a following capture: the loop path re-fires
+      the tag write on every iteration, while the path already inside the
+      capture must keep the earlier position).
 
-      Tags live on epsilon nodes in the NFA, so they are naturally collected
-      during epsilon closure. To compute a DFA transition for character
-      set [c]: follow all NFA [c]-transitions from nodes in the current DFA
-      state, then compute the epsilon closure of the targets. Every tagged
-      node visited during closure contributes its tag operation to the
-      transition's tag list. Each (target DFA state, tag list) pair becomes
-      one DFA transition: "on input [c], execute these tag ops, go to state N."
+      Configuration order is priority: epsilon closure visits nodes
+      depth-first following the order of [eps] lists (alternation prefers
+      the left branch, repetition prefers continuing the loop), and the
+      first path to reach a node wins. This yields leftmost-greedy
+      disambiguation of capture positions among parses of the (always
+      longest) match.
 
-      In general, tagged determinization must resolve conflicts when multiple
-      active NFA paths write different values to the same tag (Laurikari uses
-      per-path tag valuations and priority ordering). Sedlex largely avoids
-      this: each [as] binding gets unique tag IDs, and [as] is rejected
-      inside repetition operators, so no two active NFA paths ever write to
-      the same position tag. The one exception is discriminator cells
-      (Set_value): both branches of an alt may be simultaneously active in
-      a DFA state; [dedup_tags] resolves this by keeping the lowest value
-      (first-branch-wins).
+      Tag writes performed by a transition allocate fresh registers; the
+      target DFA state is looked up modulo a bijective renaming of
+      registers (the canonical key numbers registers by first occurrence).
+      When the lookup hits an existing state, register-move operations
+      (Copy/Set) are emitted on the transition to realign registers with
+      the existing state's maps; moves are topologically sorted, breaking
+      cycles with a temporary cell.
+
+      Accepting states carry [final_ops]: Copy operations that materialize
+      the accepting configuration's registers into the canonical cells
+      (cell index = logical tag id) read by the generated bindings. They
+      run just before [Sedlexing.mark], so the snapshot/backtrack machinery
+      needs no changes.
 
    Possible future optimizations (see #175)
    -----------------------------------------
 
-   Tag optimizations for `as` bindings:
-   - Self-loop tag delay: tags on self-loops that also appear on all
-     entering transitions can be removed from those transitions and emitted
-     as a "set previous position" on exit. This turns O(n) tag writes in
-     loops (e.g. Star) into O(1) on exit.
-   - Intra-rule tag coalescing: tags with identical occurrence signatures
-     (same presence in init_tags and same set of transitions) can share a
-     single memory cell.
-   - Cross-rule cell sharing: memory cells from non-interfering rules can
-     share the same physical slot via liveness analysis and graph coloring.
-
-   DFA construction:
+   - Self-loop tag delay: tags rewritten on every iteration of a self-loop
+     could be maintained as a "previous position" delta and written once on
+     exit, turning O(n) writes into O(1).
    - DFA minimization: the generated DFA is not minimized. Hopcroft's or
      Moore's algorithm could reduce state count, especially for patterns with
      many character classes that converge to the same accepting state.
@@ -141,7 +142,8 @@ let rec repeat r n m succ =
   assert (0 <= n && n <= m);
   match (n, m) with
     | 0, 0 -> succ
-    | 0, m -> alt eps (fun succ -> r (repeat r 0 (m - 1) succ)) succ
+    (* Taking an iteration comes first: repetition is greedy. *)
+    | 0, m -> alt (fun succ -> r (repeat r 0 (m - 1) succ)) eps succ
     | n, m -> r (repeat r (n - 1) (m - 1) succ)
 
 let compl r =
@@ -219,129 +221,352 @@ let compile_re re =
   let final = new_node () in
   (re final, final)
 
-(* Determinization *)
+(* Determinization (tagged subset construction, see overview above) *)
 
-type state = node list
-(* A DFA state is a set of NFA nodes (subset construction).
-   Membership is checked by physical identity (List.memq) since each
-   node is created exactly once by new_node/new_tagged_node. *)
+module IntMap = Map.Make (Int)
 
-(* [add_node (state, tags) node] adds [node] to the NFA-node set [state]
-   via epsilon closure: it follows all epsilon edges recursively, collecting
-   any tag operations encountered along the way. Returns the updated
-   (state, tags) pair. Physical identity (memq) prevents revisiting nodes. *)
-let rec add_node (state, tags) node =
-  if List.memq node state then (state, tags)
-  else (
-    let tags = match node.tag with Some op -> op :: tags | None -> tags in
-    add_nodes (node :: state, tags) node.eps)
+(* During transition computation, a logical tag maps to either a concrete
+   memory cell ([Old]) or a write performed by the pending transition
+   ([New]). New ids are local to one transition. *)
+type addr = Old of int | New of int
 
-and add_nodes acc nodes = List.fold_left add_node acc nodes
+(* What a [New] register will hold once the transition executes: the
+   current position, or a discriminator value. *)
+type write = Wpos | Wval of int
 
-(* When multiple Set_value ops target the same cell (because both branches
-   of an alt are simultaneously active in a DFA state), keep only the one
-   with the lowest value — this gives first-branch-wins semantics. *)
-let dedup_tags tags =
-  let dominated = Hashtbl.create 4 in
-  List.iter
-    (function
-      | Set_value (cell, value) -> (
-          match Hashtbl.find_opt dominated cell with
-            | Some v when v <= value -> ()
-            | _ -> Hashtbl.replace dominated cell value)
-      | Set_position _ | Copy _ -> ())
-    tags;
-  List.filter
-    (function
-      | Set_value (cell, value) -> Hashtbl.find dominated cell = value
-      | Set_position _ | Copy _ -> true)
-    tags
+type config = node * addr IntMap.t
+(* One active NFA path: the node it reached and, for each logical tag
+   written along the path, the register holding the recorded value.
+   A DFA state is a [config list] in priority order; in stored states
+   all addresses are [Old]. *)
 
-(* [transition state] computes all outgoing DFA transitions from a DFA state.
-   Three phases:
-   1. Normalize: collect all NFA transitions from all nodes in [state],
-      sort by target node id, and merge char sets for identical targets.
-   2. Split: make char sets pairwise disjoint so each DFA transition fires
-      for an unambiguous set of code points.
-   3. Epsilon closure: for each disjoint char set, compute the epsilon
-      closure of the target NFA nodes, collecting tag operations. *)
-let transition (state : state) =
-  (* Merge transition with the same target *)
-  let rec norm = function
-    | (c1, n1) :: ((c2, n2) :: q as l) ->
-        if n1 == n2 then norm ((Cset.union c1 c2, n1) :: q)
-        else (c1, n1) :: norm l
-    | l -> l
+(* [closure seeds] computes the priority-ordered epsilon closure of
+   [seeds]. Nodes are visited depth-first following the order of [eps]
+   lists, and the first (highest-priority) path to reach a node fixes
+   that node's register map — this implements leftmost-greedy
+   disambiguation. Tag writes encountered along the way allocate [New]
+   registers, shared between paths recording identical content. Returns
+   the configurations and the list of (New id, write) payloads. *)
+let closure (seeds : config list) =
+  let new_ids = Hashtbl.create 8 in
+  let new_writes = ref [] in
+  let n_new = ref 0 in
+  let new_id key w =
+    match Hashtbl.find_opt new_ids key with
+      | Some i -> i
+      | None ->
+          let i = !n_new in
+          incr n_new;
+          Hashtbl.add new_ids key i;
+          new_writes := (i, w) :: !new_writes;
+          i
   in
-  let t = List.concat (List.map (fun n -> n.trans) state) in
-  let t = norm (List.sort (fun (_, n1) (_, n2) -> n1.id - n2.id) t) in
+  let visited = Hashtbl.create 16 in
+  let acc = ref [] in
+  let rec visit (n, m) =
+    if not (Hashtbl.mem visited n.id) then (
+      Hashtbl.add visited n.id ();
+      let m =
+        match n.tag with
+          | None -> m
+          | Some (Set_position t) ->
+              IntMap.add t (New (new_id (`Pos t) Wpos)) m
+          | Some (Set_value (cell, v)) ->
+              IntMap.add cell (New (new_id (`Val (cell, v)) (Wval v))) m
+          | Some (Copy _) -> assert false (* never carried by NFA nodes *)
+      in
+      acc := (n, m) :: !acc;
+      List.iter (fun n' -> visit (n', m)) n.eps)
+  in
+  List.iter visit seeds;
+  (List.rev !acc, !new_writes)
 
-  (* Split char sets so as to make them disjoint *)
-  let split (all, t) (c0, n0) =
-    let t =
-      (Cset.difference c0 all, [n0])
-      :: List.map (fun (c, ns) -> (Cset.intersection c c0, n0 :: ns)) t
-      @ List.map (fun (c, ns) -> (Cset.difference c c0, ns)) t
+(* [split_moves moves] partitions the character transitions leaving a DFA
+   state into pairwise-disjoint character sets. Each resulting piece
+   carries its seed configurations in the original (priority) order. *)
+let split_moves (moves : (Cset.t * config) list) : (Cset.t * config list) list
+    =
+  let add pieces (c, cfg) =
+    let rec ins c pieces =
+      if Cset.is_empty c then pieces
+      else (
+        match pieces with
+          | [] -> [(c, [cfg])]
+          | (pc, seeds) :: rest ->
+              let inter = Cset.intersection pc c in
+              if Cset.is_empty inter then (pc, seeds) :: ins c rest
+              else (
+                let pc_only = Cset.difference pc inter in
+                let c_rest = Cset.difference c inter in
+                let with_cfg = (inter, seeds @ [cfg]) in
+                if Cset.is_empty pc_only then with_cfg :: ins c_rest rest
+                else (pc_only, seeds) :: with_cfg :: ins c_rest rest))
     in
-    (Cset.union all c0, List.filter (fun (c, _) -> not (Cset.is_empty c)) t)
+    ins c pieces
   in
-
-  let _, t = List.fold_left split (Cset.empty, []) t in
-
-  (* Epsilon closure of targets, collecting tags *)
-  let t =
-    List.map
-      (fun (c, ns) ->
-        let state, tags = add_nodes ([], []) ns in
-        (c, state, dedup_tags tags))
-      t
-  in
-
-  (* Canonical ordering *)
-  let t = Array.of_list t in
-  Array.sort (fun (c1, _, _) (c2, _, _) -> compare c1 c2) t;
-  t
+  List.fold_left add [] moves
 
 type dfa_state = {
   trans : (Cset.t * int * tag_op list) array;
   finals : bool array;
+  final_ops : tag_op list;
 }
 
 type dfa = dfa_state array
 type compiled = { dfa : dfa; init_tags : tag_op list; num_tags : int }
 
-(* [compile rs] determinizes the NFA for an array of regexp rules.
-   Each rule is compiled to an NFA (entry node, final node) pair. The initial
-   DFA state is the epsilon closure of all entry nodes. States are explored
-   via [transition] and memoized in a hash table keyed by NFA node lists
-   (physical identity). Returns a {compiled} record with the DFA, initial
-   tag operations, and total number of memory cells needed. *)
+let op_dest = function Copy (d, _) | Set_position d | Set_value (d, _) -> d
+let op_orig = function Copy (_, s) -> s | Set_position _ | Set_value _ -> -1
+
+(* [compile rs] determinizes the NFA for an array of regexp rules. See the
+   implementation overview at the top of this file. *)
 let compile rs =
   let rs = Array.map compile_re rs in
-  let counter = ref 0 in
-  let states = Hashtbl.create 31 in
-  let states_def = Hashtbl.create 31 in
-  let rec aux state =
-    try Hashtbl.find states state
-    with Not_found ->
-      let i = !counter in
-      incr counter;
-      Hashtbl.add states state i;
-      let trans = transition state in
-      let trans = Array.map (fun (p, t, tags) -> (p, aux t, tags)) trans in
-      let finals = Array.map (fun (_, f) -> List.memq f state) rs in
-      Hashtbl.add states_def i { trans; finals };
-      i
+  let num_logical = !cur_tag in
+  (* Working registers live above the canonical cells 0..num_logical-1,
+     which are written only by [final_ops] and read by the generated
+     binding-extraction code. *)
+  let next_cell = ref num_logical in
+  (* Per-logical-tag pool of working registers allocated so far; reusing
+     them keeps the total cell count small. Pools of distinct tags are
+     disjoint. *)
+  let pools : (int, int list) Hashtbl.t = Hashtbl.create 8 in
+  (* Temporary cells used to break cycles in register moves. The pool is
+     shared between transitions, but within one move set each cycle gets a
+     distinct temp (two independent cycles must not clobber each other's
+     saved value). *)
+  let temps = ref [] in
+  let fresh_temps () =
+    let avail = ref !temps in
+    fun () ->
+      match !avail with
+        | c :: rest ->
+            avail := rest;
+            c
+        | [] ->
+            let c = !next_cell in
+            incr next_cell;
+            temps := !temps @ [c];
+            c
   in
-  let init = ref ([], []) in
-  Array.iter (fun (i, _) -> init := add_node !init i) rs;
-  let init_state, init_tags = !init in
-  let i = aux init_state in
-  assert (i = 0);
+  let alloc_cell used tag =
+    let pool =
+      match Hashtbl.find_opt pools tag with Some l -> l | None -> []
+    in
+    match List.find_opt (fun c -> not (List.mem c !used)) pool with
+      | Some c ->
+          used := c :: !used;
+          c
+      | None ->
+          let c = !next_cell in
+          incr next_cell;
+          Hashtbl.replace pools tag (c :: pool);
+          used := c :: !used;
+          c
+  in
+  (* Topological sort of register moves: a move whose source is the
+     destination of another pending move must run first; cycles are broken
+     through a temporary cell (ocamllex's sort_mvs). The result list is in
+     execution order. *)
+  let sort_mvs mvs =
+    let alloc_temp = fresh_temps () in
+    let rec go sorted mvs =
+      match mvs with
+        | [] -> sorted
+        | _ -> (
+            let dests = List.map op_dest mvs in
+            let rem, here =
+              List.partition (fun mv -> List.mem (op_orig mv) dests) mvs
+            in
+            match here with
+              | [] -> (
+                  match rem with
+                    | Copy (d, _) :: _ ->
+                        let t = alloc_temp () in
+                        Copy (t, d)
+                        :: go sorted
+                             (List.map
+                                (fun mv ->
+                                  if op_orig mv = d then Copy (op_dest mv, t)
+                                  else mv)
+                                rem)
+                    | _ -> assert false)
+              | _ -> go (here @ sorted) rem)
+    in
+    go [] mvs
+  in
+  (* DFA states are looked up modulo bijective register renaming: the key
+     numbers each distinct address by first occurrence, so two states with
+     the same node order and the same register-sharing structure collide. *)
+  let state_key (configs : config list) =
+    let tbl = Hashtbl.create 8 in
+    let canon a =
+      match Hashtbl.find_opt tbl a with
+        | Some i -> i
+        | None ->
+            let i = Hashtbl.length tbl in
+            Hashtbl.add tbl a i;
+            i
+    in
+    List.map
+      (fun (n, m) ->
+        (n.id, List.map (fun (t, a) -> (t, canon a)) (IntMap.bindings m)))
+      configs
+  in
+  let states = Hashtbl.create 31 in
+  let state_configs : (int, config list) Hashtbl.t = Hashtbl.create 31 in
+  let states_def = Hashtbl.create 31 in
+  let counter = ref 0 in
+  let todo = Queue.create () in
+  (* Creating a new state: [Old] registers are kept as-is, [New] writes get
+     concrete cells; the transition only carries the Set operations. *)
+  let concretize configs new_writes =
+    let used =
+      ref
+        (List.concat_map
+           (fun ((_, m) : config) ->
+             List.filter_map
+               (fun (_, a) -> match a with Old c -> Some c | New _ -> None)
+               (IntMap.bindings m))
+           configs)
+    in
+    let assigned = Hashtbl.create 4 in
+    let ops = ref [] in
+    let cell_for_new tag i =
+      match Hashtbl.find_opt assigned i with
+        | Some c -> c
+        | None ->
+            let c = alloc_cell used tag in
+            Hashtbl.add assigned i c;
+            (match List.assoc i new_writes with
+              | Wpos -> ops := Set_position c :: !ops
+              | Wval v -> ops := Set_value (c, v) :: !ops);
+            c
+    in
+    let configs =
+      List.map
+        (fun (n, m) ->
+          ( n,
+            IntMap.mapi
+              (fun tag a ->
+                match a with
+                  | Old _ -> a
+                  | New i -> Old (cell_for_new tag i))
+              m ))
+        configs
+    in
+    (configs, !ops)
+  in
+  (* Reaching an existing state: emit the register moves that realign the
+     candidate's registers with the stored state's maps. Equal canonical
+     keys guarantee each destination cell gets a single consistent move. *)
+  let moves_to candidate new_writes existing =
+    let moves = Hashtbl.create 8 in
+    List.iter2
+      (fun ((_, m_cand) : config) ((_, m_ex) : config) ->
+        IntMap.iter
+          (fun tag a ->
+            let dst =
+              match IntMap.find tag m_ex with
+                | Old c -> c
+                | New _ -> assert false
+            in
+            match a with
+              | Old src ->
+                  if src <> dst then Hashtbl.replace moves dst (Copy (dst, src))
+              | New i -> (
+                  match List.assoc i new_writes with
+                    | Wpos -> Hashtbl.replace moves dst (Set_position dst)
+                    | Wval v -> Hashtbl.replace moves dst (Set_value (dst, v))))
+          m_cand)
+      candidate existing;
+    let mvs = Hashtbl.fold (fun _ op acc -> op :: acc) moves [] in
+    let mvs = List.sort (fun a b -> compare (op_dest a) (op_dest b)) mvs in
+    sort_mvs mvs
+  in
+  let get_state candidate new_writes =
+    let key = state_key candidate in
+    match Hashtbl.find_opt states key with
+      | Some num ->
+          (num, moves_to candidate new_writes (Hashtbl.find state_configs num))
+      | None ->
+          let configs, ops = concretize candidate new_writes in
+          let num = !counter in
+          incr counter;
+          Hashtbl.add states key num;
+          Hashtbl.add state_configs num configs;
+          Queue.push num todo;
+          (num, ops)
+  in
+  let transition configs =
+    let moves =
+      List.concat_map
+        (fun ((n, m) : config) ->
+          List.map (fun (c, n') -> (c, (n', m))) n.trans)
+        configs
+    in
+    let pieces = split_moves moves in
+    let t =
+      List.map
+        (fun (cset, seeds) ->
+          let candidate, new_writes = closure seeds in
+          let num, ops = get_state candidate new_writes in
+          (cset, num, ops))
+        pieces
+    in
+    let t = Array.of_list t in
+    Array.sort (fun (c1, _, _) (c2, _, _) -> compare c1 c2) t;
+    t
+  in
+  let lowest_final finals =
+    let n = Array.length finals in
+    let rec aux i =
+      if i = n then None else if finals.(i) then Some i else aux (i + 1)
+    in
+    aux 0
+  in
+  let finals_of configs =
+    Array.map
+      (fun (_, fin) -> List.exists (fun ((n, _) : config) -> n == fin) configs)
+      rs
+  in
+  (* Materialize the accepting configuration's registers into the
+     canonical cells (cell = logical tag id) just before [mark]. Sources
+     are working registers (>= num_logical) and destinations canonical
+     cells, so the copies never interfere with each other. *)
+  let final_ops_of configs finals =
+    match lowest_final finals with
+      | None -> []
+      | Some i ->
+          let _, fin = rs.(i) in
+          let _, m =
+            List.find (fun ((n, _) : config) -> n == fin) configs
+          in
+          IntMap.fold
+            (fun tag a acc ->
+              match a with
+                | Old c -> if c = tag then acc else Copy (tag, c) :: acc
+                | New _ -> assert false)
+            m []
+  in
+  let init_candidate, init_writes =
+    closure
+      (List.map (fun (entry, _) -> (entry, IntMap.empty)) (Array.to_list rs))
+  in
+  let num0, init_tags = get_state init_candidate init_writes in
+  assert (num0 = 0);
+  while not (Queue.is_empty todo) do
+    let num = Queue.pop todo in
+    let configs = Hashtbl.find state_configs num in
+    let trans = transition configs in
+    let finals = finals_of configs in
+    let final_ops = final_ops_of configs finals in
+    Hashtbl.add states_def num { trans; finals; final_ops }
+  done;
   {
     dfa = Array.init !counter (Hashtbl.find states_def);
-    init_tags = dedup_tags init_tags;
-    num_tags = !cur_tag;
+    init_tags;
+    num_tags = !next_cell;
   }
 
 (* High-level compilation from IR.
@@ -598,8 +823,13 @@ let dfa_to_dot dfa =
   bprintf buf "  node [shape=circle];\n\n";
   bprintf buf "  _start [shape=point];\n";
   bprintf buf "  _start -> state0;\n\n";
+  let tag_op_to_string = function
+    | Set_position t -> "t" ^ string_of_int t
+    | Set_value (c, v) -> "d" ^ string_of_int c ^ "=" ^ string_of_int v
+    | Copy (dst, src) -> "t" ^ string_of_int dst ^ "<-t" ^ string_of_int src
+  in
   Array.iteri
-    (fun i { trans; finals } ->
+    (fun i { trans; finals; final_ops } ->
       let accepted =
         let acc = ref [] in
         for r = Array.length finals - 1 downto 0 do
@@ -610,18 +840,21 @@ let dfa_to_dot dfa =
       (match accepted with
         | [] -> bprintf buf "  state%d [label=\"%d\"];\n" i i
         | rules ->
+            let ops =
+              if final_ops = [] then ""
+              else
+                "\\n{"
+                ^ String.concat "," (List.map tag_op_to_string final_ops)
+                ^ "}"
+            in
             bprintf buf
-              "  state%d [label=\"%d\\n[rule %s]\", shape=doublecircle];\n" i i
-              (String.concat "," (List.map string_of_int rules)));
+              "  state%d [label=\"%d\\n[rule %s]%s\", shape=doublecircle];\n" i
+              i
+              (String.concat "," (List.map string_of_int rules))
+              ops);
       Array.iter
         (fun (cset, target, tags) ->
           let label = cset_to_label cset in
-          let tag_op_to_string = function
-            | Set_position t -> "t" ^ string_of_int t
-            | Set_value (c, v) -> "d" ^ string_of_int c ^ "=" ^ string_of_int v
-            | Copy (dst, src) ->
-                "t" ^ string_of_int dst ^ "<-t" ^ string_of_int src
-          in
           let label =
             if tags = [] then label
             else

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -86,10 +86,7 @@ module Cset = Cset
 
 (* NFA *)
 
-type tag_op =
-  | Set_position of int
-  | Set_value of int * int
-  | Copy of int * int
+type tag_op = Set_position of int | Set_value of int * int | Copy of int * int
 
 type node = {
   id : int;  (** Unique identifier, used for sorting transitions by target. *)
@@ -244,7 +241,6 @@ type addr = Old of int | New of int
 (* What a [New] register will hold once the transition executes: the
    current position, or a discriminator value. *)
 type write = Wpos | Wval of int
-
 type config = node * addr IntMap.t
 (* One active NFA path: the node it reached and, for each logical tag
    written along the path, the register holding the recorded value.
@@ -280,8 +276,7 @@ let closure (seeds : config list) =
       let m =
         match n.tag with
           | None -> m
-          | Some (Set_position t) ->
-              IntMap.add t (New (new_id (`Pos t) Wpos)) m
+          | Some (Set_position t) -> IntMap.add t (New (new_id (`Pos t) Wpos)) m
           | Some (Set_value (cell, v)) ->
               IntMap.add cell (New (new_id (`Val (cell, v)) (Wval v))) m
           | Some (Copy _) -> assert false (* never carried by NFA nodes *)
@@ -300,8 +295,7 @@ let closure (seeds : config list) =
 (* [split_moves moves] partitions the character transitions leaving a DFA
    state into pairwise-disjoint character sets. Each resulting piece
    carries its seed configurations in the original (priority) order. *)
-let split_moves (moves : (Cset.t * config) list) : (Cset.t * config list) list
-    =
+let split_moves (moves : (Cset.t * config) list) : (Cset.t * config list) list =
   let add pieces (c, cfg) =
     let rec ins c pieces =
       if Cset.is_empty c then pieces
@@ -415,9 +409,7 @@ let compile rs =
           ( n,
             IntMap.mapi
               (fun tag a ->
-                match a with
-                  | Old _ -> a
-                  | New i -> Old (cell_for_new tag i))
+                match a with Old _ -> a | New i -> Old (cell_for_new tag i))
               m ))
         configs
     in
@@ -525,9 +517,7 @@ let compile rs =
       | None -> []
       | Some i ->
           let _, fin = rs.(i) in
-          let _, m =
-            List.find (fun ((n, _) : config) -> n == fin) configs
-          in
+          let _, m = List.find (fun ((n, _) : config) -> n == fin) configs in
           IntMap.fold
             (fun tag a acc ->
               match a with

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -421,7 +421,6 @@ type state_table = {
   by_key : (state_key, int) Hashtbl.t;
   configs : (int, config list) Hashtbl.t;
       (* Stored configurations; all addresses are [Old]. *)
-  defs : (int, dfa_state) Hashtbl.t; (* Filled by the main loop. *)
   mutable n_states : int;
   todo : int Queue.t; (* States whose transitions are not yet built. *)
 }
@@ -430,7 +429,6 @@ let make_state_table () =
   {
     by_key = Hashtbl.create 31;
     configs = Hashtbl.create 31;
-    defs = Hashtbl.create 31;
     n_states = 0;
     todo = Queue.create ();
   }
@@ -616,18 +614,19 @@ let compile rs =
   in
   let num0, init_tags = get_state regs tbl init_candidate init_writes in
   assert (num0 = 0);
+  let defs : (int, dfa_state) Hashtbl.t = Hashtbl.create 31 in
   while not (Queue.is_empty tbl.todo) do
     let num = Queue.pop tbl.todo in
     let configs = Hashtbl.find tbl.configs num in
     let trans = transition regs tbl configs in
     let finals = finals_of rs configs in
     let final_ops = final_ops_of rs configs finals in
-    Hashtbl.add tbl.defs num { trans; finals; final_ops }
+    Hashtbl.add defs num { trans; finals; final_ops }
   done;
   let cell_map, num_tags = collapse_conflict_free regs in
   let dfa =
     Array.init tbl.n_states (fun i ->
-        let s = Hashtbl.find tbl.defs i in
+        let s = Hashtbl.find defs i in
         {
           s with
           trans =

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -86,7 +86,10 @@ module Cset = Cset
 
 (* NFA *)
 
-type tag_op = Set_position of int | Set_value of int * int | Copy of int * int
+type tag_op =
+  | Set_position of { dst : int }
+  | Set_value of { dst : int; value : int }
+  | Copy of { dst : int; src : int }
 
 type node = {
   id : int;  (** Unique identifier, used for sorting transitions by target. *)
@@ -185,10 +188,10 @@ let bind r =
   let start_tag = new_tag () in
   let end_tag = new_tag () in
   let wrapped succ =
-    let end_node = new_tagged_node (Set_position end_tag) in
+    let end_node = new_tagged_node (Set_position { dst = end_tag }) in
     end_node.eps <- [succ];
     let inner = r end_node in
-    let start_node = new_tagged_node (Set_position start_tag) in
+    let start_node = new_tagged_node (Set_position { dst = start_tag }) in
     start_node.eps <- [inner];
     start_node
   in
@@ -198,7 +201,7 @@ let bind_start_only r =
   let start_tag = new_tag () in
   let wrapped succ =
     let inner = r succ in
-    let start_node = new_tagged_node (Set_position start_tag) in
+    let start_node = new_tagged_node (Set_position { dst = start_tag }) in
     start_node.eps <- [inner];
     start_node
   in
@@ -207,7 +210,7 @@ let bind_start_only r =
 let bind_end_only r =
   let end_tag = new_tag () in
   let wrapped succ =
-    let end_node = new_tagged_node (Set_position end_tag) in
+    let end_node = new_tagged_node (Set_position { dst = end_tag }) in
     end_node.eps <- [succ];
     r end_node
   in
@@ -217,7 +220,7 @@ let new_disc_cell () = new_tag ()
 
 let bind_disc r cell value =
   let wrapped succ =
-    let disc_node = new_tagged_node (Set_value (cell, value)) in
+    let disc_node = new_tagged_node (Set_value { dst = cell; value }) in
     disc_node.eps <- [succ];
     r disc_node
   in
@@ -276,8 +279,9 @@ let closure (seeds : config list) =
       let m =
         match n.tag with
           | None -> m
-          | Some (Set_position t) -> IntMap.add t (New (new_id (`Pos t) Wpos)) m
-          | Some (Set_value (cell, v)) ->
+          | Some (Set_position { dst = t }) ->
+              IntMap.add t (New (new_id (`Pos t) Wpos)) m
+          | Some (Set_value { dst = cell; value = v }) ->
               IntMap.add cell (New (new_id (`Val (cell, v)) (Wval v))) m
           | Some (Copy _) -> assert false (* never carried by NFA nodes *)
       in
@@ -325,7 +329,8 @@ type dfa_state = {
 type dfa = dfa_state array
 type compiled = { dfa : dfa; init_tags : tag_op list; num_tags : int }
 
-let op_dest = function Copy (d, _) | Set_position d | Set_value (d, _) -> d
+let op_dest = function
+  | Copy { dst; _ } | Set_position { dst } | Set_value { dst; _ } -> dst
 
 (* [compile rs] determinizes the NFA for an array of regexp rules. See the
    implementation overview at the top of this file. *)
@@ -399,8 +404,8 @@ let compile rs =
             let c = alloc_cell used tag in
             Hashtbl.add assigned i c;
             (match List.assoc i new_writes with
-              | Wpos -> ops := Set_position c :: !ops
-              | Wval v -> ops := Set_value (c, v) :: !ops);
+              | Wpos -> ops := Set_position { dst = c } :: !ops
+              | Wval v -> ops := Set_value { dst = c; value = v } :: !ops);
             c
     in
     let configs =
@@ -433,11 +438,14 @@ let compile rs =
             in
             match a with
               | Old src ->
-                  if src <> dst then Hashtbl.replace moves dst (Copy (dst, src))
+                  if src <> dst then
+                    Hashtbl.replace moves dst (Copy { dst; src })
               | New i -> (
                   match List.assoc i new_writes with
-                    | Wpos -> Hashtbl.replace moves dst (Set_position dst)
-                    | Wval v -> Hashtbl.replace moves dst (Set_value (dst, v))))
+                    | Wpos -> Hashtbl.replace moves dst (Set_position { dst })
+                    | Wval v ->
+                        Hashtbl.replace moves dst (Set_value { dst; value = v })
+                  ))
           m_cand)
       candidate existing;
     let mvs = Hashtbl.fold (fun _ op acc -> op :: acc) moves [] in
@@ -521,7 +529,8 @@ let compile rs =
           IntMap.fold
             (fun tag a acc ->
               match a with
-                | Old c -> if c = tag then acc else Copy (tag, c) :: acc
+                | Old c ->
+                    if c = tag then acc else Copy { dst = tag; src = c } :: acc
                 | New _ -> assert false)
             m []
   in
@@ -562,11 +571,12 @@ let compile rs =
     List.filter_map
       (fun op ->
         match op with
-          | Set_position d -> Some (Set_position cell_map.(d))
-          | Set_value (d, v) -> Some (Set_value (cell_map.(d), v))
-          | Copy (d, s) ->
-              let d = cell_map.(d) and s = cell_map.(s) in
-              if d = s then None else Some (Copy (d, s)))
+          | Set_position { dst } -> Some (Set_position { dst = cell_map.(dst) })
+          | Set_value { dst; value } ->
+              Some (Set_value { dst = cell_map.(dst); value })
+          | Copy { dst; src } ->
+              let dst = cell_map.(dst) and src = cell_map.(src) in
+              if dst = src then None else Some (Copy { dst; src }))
       ops
   in
   let dfa =
@@ -822,9 +832,10 @@ let dfa_to_dot dfa =
   bprintf buf "  _start [shape=point];\n";
   bprintf buf "  _start -> state0;\n\n";
   let tag_op_to_string = function
-    | Set_position t -> "t" ^ string_of_int t
-    | Set_value (c, v) -> "d" ^ string_of_int c ^ "=" ^ string_of_int v
-    | Copy (dst, src) -> "t" ^ string_of_int dst ^ "<-t" ^ string_of_int src
+    | Set_position { dst } -> "t" ^ string_of_int dst
+    | Set_value { dst; value } ->
+        "d" ^ string_of_int dst ^ "=" ^ string_of_int value
+    | Copy { dst; src } -> "t" ^ string_of_int dst ^ "<-t" ^ string_of_int src
   in
   Array.iteri
     (fun i { trans; finals; final_ops } ->

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -260,13 +260,11 @@ type config = node * addr IntMap.t
 let closure (seeds : config list) =
   let new_ids = Hashtbl.create 8 in
   let new_writes = ref [] in
-  let n_new = ref 0 in
   let new_id key w =
     match Hashtbl.find_opt new_ids key with
       | Some i -> i
       | None ->
-          let i = !n_new in
-          incr n_new;
+          let i = Hashtbl.length new_ids in
           Hashtbl.add new_ids key i;
           new_writes := (i, w) :: !new_writes;
           i

--- a/src/compiler/sedlex.ml
+++ b/src/compiler/sedlex.ml
@@ -234,7 +234,7 @@ let compile_re re =
 
 (* Determinization (tagged subset construction, see overview above) *)
 
-module IntMap = Map.Make (Int)
+module TagMap = Map.Make (Int)
 
 (* During transition computation, a logical tag maps to either a concrete
    memory cell ([Old]) or a write performed by the pending transition
@@ -244,7 +244,7 @@ type addr = Old of int | New of int
 (* What a [New] register will hold once the transition executes: the
    current position, or a discriminator value. *)
 type write = Wpos | Wval of int
-type config = node * addr IntMap.t
+type config = node * addr TagMap.t
 (* One active NFA path: the node it reached and, for each logical tag
    written along the path, the register holding the recorded value.
    A DFA state is a [config list] in priority order; in stored states
@@ -278,9 +278,9 @@ let closure (seeds : config list) =
         match n.tag with
           | None -> m
           | Some (Set_position { dst = t }) ->
-              IntMap.add t (New (new_id (`Pos t) Wpos)) m
+              TagMap.add t (New (new_id (`Pos t) Wpos)) m
           | Some (Set_value { dst = cell; value = v }) ->
-              IntMap.add cell (New (new_id (`Val (cell, v)) (Wval v))) m
+              TagMap.add cell (New (new_id (`Val (cell, v)) (Wval v))) m
           | Some (Copy _) -> assert false (* never carried by NFA nodes *)
       in
       (* Keep only configurations that matter: nodes with outgoing char
@@ -386,7 +386,7 @@ let check_conflicts regs configs =
   let seen = Hashtbl.create 8 in
   List.iter
     (fun ((_, m) : config) ->
-      IntMap.iter
+      TagMap.iter
         (fun tag a ->
           match Hashtbl.find_opt seen tag with
             | None -> Hashtbl.add seen tag a
@@ -411,7 +411,7 @@ let state_key (configs : config list) : state_key =
   in
   List.map
     (fun (n, m) ->
-      (n.id, List.map (fun (t, a) -> (t, canon a)) (IntMap.bindings m)))
+      (n.id, List.map (fun (t, a) -> (t, canon a)) (TagMap.bindings m)))
     configs
 
 (* DFA states discovered so far, numbered in creation order. *)
@@ -440,7 +440,7 @@ let concretize regs configs new_writes =
          (fun ((_, m) : config) ->
            List.filter_map
              (fun (_, a) -> match a with Old c -> Some c | New _ -> None)
-             (IntMap.bindings m))
+             (TagMap.bindings m))
          configs)
   in
   let assigned = Hashtbl.create 4 in
@@ -460,7 +460,7 @@ let concretize regs configs new_writes =
     List.map
       (fun (n, m) ->
         ( n,
-          IntMap.mapi
+          TagMap.mapi
             (fun tag a ->
               match a with Old _ -> a | New i -> Old (cell_for_new tag i))
             m ))
@@ -482,10 +482,10 @@ let moves_to candidate new_writes existing =
   in
   List.iter2
     (fun ((_, m_cand) : config) ((_, m_ex) : config) ->
-      IntMap.iter
+      TagMap.iter
         (fun tag a ->
           let dst =
-            match IntMap.find tag m_ex with Old c -> c | New _ -> assert false
+            match TagMap.find tag m_ex with Old c -> c | New _ -> assert false
           in
           match a with
             | Old src -> if src <> dst then set_move dst (Copy { dst; src })
@@ -561,7 +561,7 @@ let final_ops_of regs rs configs finals =
     | Some i ->
         let _, fin = rs.(i) in
         let _, m = List.find (fun ((n, _) : config) -> n == fin) configs in
-        IntMap.fold
+        TagMap.fold
           (fun tag a acc ->
             match a with
               | Old c ->
@@ -622,7 +622,7 @@ let compile rs =
   let tbl = make_state_table () in
   let init_candidate, init_writes =
     closure
-      (List.map (fun (entry, _) -> (entry, IntMap.empty)) (Array.to_list rs))
+      (List.map (fun (entry, _) -> (entry, TagMap.empty)) (Array.to_list rs))
   in
   let num0, init_tags = get_state regs tbl init_candidate init_writes in
   assert (num0 = 0);

--- a/src/compiler/sedlex.mli
+++ b/src/compiler/sedlex.mli
@@ -70,6 +70,9 @@ type tag_op =
           Emitted when determinization must preserve a position that a parallel
           NFA path is about to overwrite. *)
 
+(** [op_dest op] is the memory cell written by [op]. *)
+val op_dest : tag_op -> int
+
 (** [bind r] wraps [r] with start/end tag epsilon nodes. Returns
     [(wrapped_regexp, start_tag, end_tag)] where [start_tag] and [end_tag] are
     the allocated memory cell indices. *)
@@ -104,12 +107,17 @@ type dfa_state = {
           of the same list executed, and no two operations write the same cell.
       *)
   finals : bool array;
-      (** [finals.(i)] is [true] if this state is accepting for rule [i]. *)
-  final_ops : tag_op list;
-      (** Operations materializing the accepting path's registers into the
-          canonical cells (cell index = logical tag id) read by the binding
-          extraction code. Executed when entering the state, just before
-          [Sedlexing.mark]. Empty for non-accepting states. *)
+      (** [finals.(i)] is [true] if this state is accepting for rule [i]. Kept
+          for {!dfa_to_dot} (which displays every accepting rule); code driving
+          the automaton should use [accept], which resolves rule priority. *)
+  accept : (int * tag_op list) option;
+      (** For an accepting state, [Some (rule, final_ops)]: [rule] is the
+          lowest-numbered — hence highest-priority — accepting rule, matching
+          the first-match semantics of [match%sedlex], and [final_ops]
+          materializes that path's registers into the canonical cells (cell
+          index = logical tag id) read by the binding extraction code, executed
+          when entering the state just before [Sedlexing.mark]. [None] for
+          non-accepting states. *)
 }
 
 (** DFA states, indexed by state number. State 0 is the initial state. *)

--- a/src/compiler/sedlex.mli
+++ b/src/compiler/sedlex.mli
@@ -100,9 +100,9 @@ type dfa_state = {
   trans : (Cset.t * int * tag_op list) array;
       (** Each transition: (character set, target state, tag operations to
           execute when this transition fires). The operations form a parallel
-          move: every [Copy] reads its source as it was {b before} any
-          operation of the same list executed, and no two operations write the
-          same cell. *)
+          move: every [Copy] reads its source as it was {b before} any operation
+          of the same list executed, and no two operations write the same cell.
+      *)
   finals : bool array;
       (** [finals.(i)] is [true] if this state is accepting for rule [i]. *)
   final_ops : tag_op list;

--- a/src/compiler/sedlex.mli
+++ b/src/compiler/sedlex.mli
@@ -59,14 +59,14 @@ val intersection : regexp -> regexp -> regexp option
 
 (** Tag operations emitted on DFA transitions. *)
 type tag_op =
-  | Set_position of int
-      (** [Set_position i]: record the current lexbuf position in memory cell
-          [i]. *)
-  | Set_value of int * int
-      (** [Set_value (cell, v)]: record integer [v] in memory cell [cell] (used
-          for or-pattern discriminators). *)
-  | Copy of int * int
-      (** [Copy (dst, src)]: copy the contents of cell [src] into cell [dst].
+  | Set_position of { dst : int }
+      (** [Set_position {dst}]: record the current lexbuf position in memory
+          cell [dst]. *)
+  | Set_value of { dst : int; value : int }
+      (** [Set_value {dst; value}]: record integer [value] in memory cell [dst]
+          (used for or-pattern discriminators). *)
+  | Copy of { dst : int; src : int }
+      (** [Copy {dst; src}]: copy the contents of cell [src] into cell [dst].
           Emitted when determinization must preserve a position that a parallel
           NFA path is about to overwrite. *)
 

--- a/src/compiler/sedlex.mli
+++ b/src/compiler/sedlex.mli
@@ -99,7 +99,10 @@ val reset_tags : unit -> unit
 type dfa_state = {
   trans : (Cset.t * int * tag_op list) array;
       (** Each transition: (character set, target state, tag operations to
-          execute when this transition fires, in list order). *)
+          execute when this transition fires). The operations form a parallel
+          move: every [Copy] reads its source as it was {b before} any
+          operation of the same list executed, and no two operations write the
+          same cell. *)
   finals : bool array;
       (** [finals.(i)] is [true] if this state is accepting for rule [i]. *)
   final_ops : tag_op list;

--- a/src/compiler/sedlex.mli
+++ b/src/compiler/sedlex.mli
@@ -65,6 +65,10 @@ type tag_op =
   | Set_value of int * int
       (** [Set_value (cell, v)]: record integer [v] in memory cell [cell] (used
           for or-pattern discriminators). *)
+  | Copy of int * int
+      (** [Copy (dst, src)]: copy the contents of cell [src] into cell [dst].
+          Emitted when determinization must preserve a position that a parallel
+          NFA path is about to overwrite. *)
 
 (** [bind r] wraps [r] with start/end tag epsilon nodes. Returns
     [(wrapped_regexp, start_tag, end_tag)] where [start_tag] and [end_tag] are

--- a/src/compiler/sedlex.mli
+++ b/src/compiler/sedlex.mli
@@ -99,9 +99,14 @@ val reset_tags : unit -> unit
 type dfa_state = {
   trans : (Cset.t * int * tag_op list) array;
       (** Each transition: (character set, target state, tag operations to
-          execute when this transition fires). *)
+          execute when this transition fires, in list order). *)
   finals : bool array;
       (** [finals.(i)] is [true] if this state is accepting for rule [i]. *)
+  final_ops : tag_op list;
+      (** Operations materializing the accepting path's registers into the
+          canonical cells (cell index = logical tag id) read by the binding
+          extraction code. Executed when entering the state, just before
+          [Sedlexing.mark]. Empty for non-accepting states. *)
 }
 
 (** DFA states, indexed by state number. State 0 is the initial state. *)
@@ -114,8 +119,9 @@ type compiled = {
       (** Tag operations to execute before entering the DFA (from epsilon
           closure of the initial NFA nodes). *)
   num_tags : int;
-      (** Total number of memory cells needed at runtime. When [num_tags = 0],
-          no memory is allocated (pattern has no [as] bindings). *)
+      (** Total number of memory cells needed at runtime (canonical cells plus
+          working registers). When [num_tags = 0], no memory is allocated
+          (pattern has no [as] bindings). *)
 }
 
 (** [compile rules] determinizes the NFA for an array of regexp rules using

--- a/src/lib/sedlexing.ml
+++ b/src/lib/sedlexing.ml
@@ -276,11 +276,23 @@ let restore_mem lexbuf =
   if n > 0 then
     Array.blit lexbuf.__private__mem_saved 0 lexbuf.__private__mem 0 n
 
+(* An accepting state should record its match only when it beats the one
+   already marked: a strictly longer match always wins, and among matches of
+   equal length the lowest-numbered (highest-priority) rule wins — the
+   first-match semantics of [match%sedlex]. Without this, a zero-width [eof]
+   transition (which reaches a new accepting state without advancing [pos])
+   would overwrite an equal-length, higher-priority match marked just before.
+   [marked_val < 0] is the "no match yet" sentinel set by [start]. *)
+let[@inline] mark_improves lexbuf i =
+  lexbuf.marked_val < 0 || lexbuf.pos > lexbuf.marked_pos || i < lexbuf.marked_val
+
 (* Public API (also usable by hand-written lexers): mark/start/backtrack carry
    the mem snapshot along with the position bookkeeping. *)
 let mark lexbuf i =
-  mark_pos lexbuf i;
-  snapshot_mem lexbuf
+  if mark_improves lexbuf i then begin
+    mark_pos lexbuf i;
+    snapshot_mem lexbuf
+  end
 
 let start lexbuf =
   start_pos lexbuf;
@@ -298,7 +310,10 @@ let backtrack lexbuf =
    path never blits cells left over from an earlier tagged block on the same
    lexbuf. Tagged blocks keep using [mark]/[backtrack] to snapshot/restore. *)
 let __private__start = start_pos
-let __private__mark_no_mem = mark_pos
+
+let __private__mark_no_mem lexbuf i =
+  if mark_improves lexbuf i then mark_pos lexbuf i
+
 let __private__backtrack_no_mem = backtrack_pos
 
 let rollback lexbuf =

--- a/src/lib/sedlexing.ml
+++ b/src/lib/sedlexing.ml
@@ -239,38 +239,67 @@ let[@inline always] next_aux some none lexbuf =
 let next lexbuf = (next_aux [@inlined]) (fun x -> Some x) None lexbuf
 let __private__next_int lexbuf = (next_aux [@inlined]) Uchar.to_int (-1) lexbuf
 
-let mark lexbuf i =
+let[@inline] mark_pos lexbuf i =
   lexbuf.marked_pos <- lexbuf.pos;
   lexbuf.marked_bytes_pos <- lexbuf.bytes_pos;
   lexbuf.marked_bol <- lexbuf.curr_bol;
   lexbuf.marked_bytes_bol <- lexbuf.curr_bytes_bol;
   lexbuf.marked_line <- lexbuf.curr_line;
-  lexbuf.marked_val <- i;
-  (* Snapshot tagged DFA memory cells so backtrack can restore them. *)
-  let n = Array.length lexbuf.__private__mem in
-  if n > 0 then
-    Array.blit lexbuf.__private__mem 0 lexbuf.__private__mem_saved 0 n
+  lexbuf.marked_val <- i
 
-let start lexbuf =
+let[@inline] start_pos lexbuf =
   lexbuf.start_pos <- lexbuf.pos;
   lexbuf.start_bytes_pos <- lexbuf.bytes_pos;
   lexbuf.start_bol <- lexbuf.curr_bol;
   lexbuf.start_bytes_bol <- lexbuf.curr_bytes_bol;
   lexbuf.start_line <- lexbuf.curr_line;
-  mark lexbuf (-1)
+  mark_pos lexbuf (-1)
 
-let backtrack lexbuf =
+let[@inline] backtrack_pos lexbuf =
   lexbuf.pos <- lexbuf.marked_pos;
   lexbuf.bytes_pos <- lexbuf.marked_bytes_pos;
   lexbuf.curr_bol <- lexbuf.marked_bol;
   lexbuf.curr_bytes_bol <- lexbuf.marked_bytes_bol;
   lexbuf.curr_line <- lexbuf.marked_line;
-  (* Restore tagged DFA memory cells to the snapshot taken at the last
-     accepting state, so sub-match positions are correct after backtracking. *)
+  lexbuf.marked_val
+
+(* Snapshot / restore the tagged DFA memory cells, so backtrack can restore the
+   sub-match positions recorded at the last accepting state. No-op when the
+   lexbuf has no cells. *)
+let snapshot_mem lexbuf =
   let n = Array.length lexbuf.__private__mem in
   if n > 0 then
-    Array.blit lexbuf.__private__mem_saved 0 lexbuf.__private__mem 0 n;
-  lexbuf.marked_val
+    Array.blit lexbuf.__private__mem 0 lexbuf.__private__mem_saved 0 n
+
+let restore_mem lexbuf =
+  let n = Array.length lexbuf.__private__mem in
+  if n > 0 then
+    Array.blit lexbuf.__private__mem_saved 0 lexbuf.__private__mem 0 n
+
+(* Public API (also usable by hand-written lexers): mark/start/backtrack carry
+   the mem snapshot along with the position bookkeeping. *)
+let mark lexbuf i =
+  mark_pos lexbuf i;
+  snapshot_mem lexbuf
+
+let start lexbuf =
+  start_pos lexbuf;
+  snapshot_mem lexbuf
+
+let backtrack lexbuf =
+  let v = backtrack_pos lexbuf in
+  restore_mem lexbuf;
+  v
+
+(* PPX entry points. [__private__start] skips the mem snapshot: a tagged block
+   re-establishes the baseline with [__private__init_mem] immediately after,
+   and a tagless block never reads mem — so the snapshot would be dead work.
+   Tagless blocks also use the [_no_mem] mark/backtrack so their hot accepting
+   path never blits cells left over from an earlier tagged block on the same
+   lexbuf. Tagged blocks keep using [mark]/[backtrack] to snapshot/restore. *)
+let __private__start = start_pos
+let __private__mark_no_mem = mark_pos
+let __private__backtrack_no_mem = backtrack_pos
 
 let rollback lexbuf =
   lexbuf.pos <- lexbuf.start_pos;

--- a/src/lib/sedlexing.ml
+++ b/src/lib/sedlexing.ml
@@ -308,6 +308,13 @@ let __private__set_mem_value lexbuf i v =
 let __private__copy_mem lexbuf dst src =
   lexbuf.__private__mem.(dst) <- lexbuf.__private__mem.(src)
 
+(* Raw cell access, used by generated code to save a cell in a local
+   variable when a parallel register move both reads and overwrites it. The
+   value is opaque (position/value encoding preserved); [__private__mem_set]
+   must only be given values obtained from [__private__mem_get]. *)
+let __private__mem_get lexbuf i = lexbuf.__private__mem.(i)
+let __private__mem_set lexbuf i v = lexbuf.__private__mem.(i) <- v
+
 (* Returns position relative to token start, for use in sub_lexeme. *)
 let __private__mem_pos lexbuf i = lexbuf.__private__mem.(i) - lexbuf.start_pos
 

--- a/src/lib/sedlexing.ml
+++ b/src/lib/sedlexing.ml
@@ -304,6 +304,10 @@ let __private__set_mem_value lexbuf i v =
   assert (v >= 0);
   lexbuf.__private__mem.(i) <- -(v + 2)
 
+(* Copies the raw cell contents, preserving the position/value encoding. *)
+let __private__copy_mem lexbuf dst src =
+  lexbuf.__private__mem.(dst) <- lexbuf.__private__mem.(src)
+
 (* Returns position relative to token start, for use in sub_lexeme. *)
 let __private__mem_pos lexbuf i = lexbuf.__private__mem.(i) - lexbuf.start_pos
 

--- a/src/lib/sedlexing.mli
+++ b/src/lib/sedlexing.mli
@@ -266,6 +266,16 @@ val __private__set_mem_value : lexbuf -> int -> int -> unit
     operations on DFA transitions. *)
 val __private__copy_mem : lexbuf -> int -> int -> unit
 
+(** [__private__mem_get lexbuf i] returns the raw contents of cell [i]. Used by
+    generated code to save a cell in a local variable when a parallel register
+    move both reads and overwrites it. The returned value is opaque; only pass
+    it to {!__private__mem_set}. *)
+val __private__mem_get : lexbuf -> int -> int
+
+(** [__private__mem_set lexbuf i v] stores [v] — a value previously obtained
+    from {!__private__mem_get} — into cell [i]. *)
+val __private__mem_set : lexbuf -> int -> int -> unit
+
 (** [__private__mem_pos lexbuf i] returns the position stored in cell [i], as an
     offset relative to the start of the current token. *)
 val __private__mem_pos : lexbuf -> int -> int

--- a/src/lib/sedlexing.mli
+++ b/src/lib/sedlexing.mli
@@ -234,6 +234,22 @@ val backtrack : lexbuf -> int
     and can be removed at any time. *)
 val __private__next_int : lexbuf -> int
 
+(** [__private__start], [__private__mark_no_mem] and [__private__backtrack_no_mem]
+    are the entry points emitted by generated code. They behave like {!start},
+    {!mark} and {!backtrack} but skip the tagged-mem snapshot/restore:
+    [__private__start] because a block using [as] bindings re-initializes the
+    cells with {!__private__init_mem} right after (and a block without bindings
+    never reads them); the [_no_mem] mark/backtrack are used only by blocks with
+    no [as] bindings, whose hot path must not blit cells left over from an
+    earlier block on the same lexbuf. Blocks with bindings keep using {!mark}
+    and {!backtrack}.
+
+    This is a private API used by generated code and may change at any time. *)
+val __private__start : lexbuf -> unit
+
+val __private__mark_no_mem : lexbuf -> int -> unit
+val __private__backtrack_no_mem : lexbuf -> int
+
 (** Tagged DFA memory cells for [as] bindings.
 
     The following functions manage an internal array of memory cells used to

--- a/src/lib/sedlexing.mli
+++ b/src/lib/sedlexing.mli
@@ -212,10 +212,14 @@ val start : lexbuf -> unit
     is incremented. *)
 val next : lexbuf -> Uchar.t option
 
-(** [mark lexbuf i] stores the integer [i] in the internal slot. The backtrack
-    position is set to the current position. If the lexbuf has tagged DFA memory
-    cells (from [as] bindings), the current cell values are snapshotted so they
-    can be restored by [backtrack]. *)
+(** [mark lexbuf i] records rule [i] and the current position as the current
+    match, but only if it improves on the match already marked since [start]: a
+    strictly longer match always wins, and among equal-length matches the
+    lowest-numbered [i] wins (the first-match semantics of [match%sedlex]). This
+    keeps a zero-width [eof] transition from overriding an equal-length,
+    higher-priority match. When it does record, the backtrack position is set to
+    the current position, and if the lexbuf has tagged DFA memory cells (from
+    [as] bindings) their values are snapshotted for [backtrack] to restore. *)
 val mark : lexbuf -> int -> unit
 
 (** [backtrack lexbuf] returns the value stored in the internal slot of the

--- a/src/lib/sedlexing.mli
+++ b/src/lib/sedlexing.mli
@@ -261,6 +261,11 @@ val __private__set_mem_pos : lexbuf -> int -> unit
 *)
 val __private__set_mem_value : lexbuf -> int -> int -> unit
 
+(** [__private__copy_mem lexbuf dst src] copies the contents of cell [src] into
+    cell [dst], preserving the position/value encoding. Used by [Copy] tag
+    operations on DFA transitions. *)
+val __private__copy_mem : lexbuf -> int -> int -> unit
+
 (** [__private__mem_pos lexbuf i] returns the position stored in cell [i], as an
     offset relative to the start of the current token. *)
 val __private__mem_pos : lexbuf -> int -> int

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -238,7 +238,8 @@ let gen_tag_ops lexbuf (ops : Sedlex.tag_op list) cont =
   let dests =
     List.map
       (fun (op : Sedlex.tag_op) ->
-        match op with Copy (d, _) | Set_position d | Set_value (d, _) -> d)
+        match op with
+          | Copy { dst; _ } | Set_position { dst } | Set_value { dst; _ } -> dst)
       ops
   in
   let clobbered =
@@ -246,7 +247,7 @@ let gen_tag_ops lexbuf (ops : Sedlex.tag_op list) cont =
       (List.filter_map
          (fun (op : Sedlex.tag_op) ->
            match op with
-             | Copy (_, s) when List.mem s dests -> Some s
+             | Copy { src; _ } when List.mem src dests -> Some src
              | _ -> None)
          ops)
   in
@@ -255,21 +256,21 @@ let gen_tag_ops lexbuf (ops : Sedlex.tag_op list) cont =
     List.fold_right
       (fun (op : Sedlex.tag_op) acc ->
         match op with
-          | Set_position t ->
+          | Set_position { dst } ->
               [%expr
-                Sedlexing.__private__set_mem_pos [%e lexbuf] [%e eint ~loc t];
+                Sedlexing.__private__set_mem_pos [%e lexbuf] [%e eint ~loc dst];
                 [%e acc]]
-          | Set_value (cell, value) ->
+          | Set_value { dst; value } ->
               [%expr
                 Sedlexing.__private__set_mem_value [%e lexbuf]
-                  [%e eint ~loc cell] [%e eint ~loc value];
+                  [%e eint ~loc dst] [%e eint ~loc value];
                 [%e acc]]
-          | Copy (dst, src) when List.mem src clobbered ->
+          | Copy { dst; src } when List.mem src clobbered ->
               [%expr
                 Sedlexing.__private__mem_set [%e lexbuf] [%e eint ~loc dst]
                   [%e evar ~loc (local src)];
                 [%e acc]]
-          | Copy (dst, src) ->
+          | Copy { dst; src } ->
               [%expr
                 Sedlexing.__private__copy_mem [%e lexbuf] [%e eint ~loc dst]
                   [%e eint ~loc src];

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -393,7 +393,7 @@ let gen_definition ((_, lexbuf) as lexbuf_with_name)
             [%e eint ~loc compiled.num_tags]]
       in
       let set_init_tags =
-        gen_tag_ops lexbuf compiled.init_tags (appfun (state_fun 0) [lexbuf])
+        gen_tag_ops lexbuf compiled.init_tags (call_state lexbuf auto 0)
       in
       pexp_sequence ~loc
         [%expr Sedlexing.start [%e lexbuf]]
@@ -401,11 +401,18 @@ let gen_definition ((_, lexbuf) as lexbuf_with_name)
     else
       pexp_sequence ~loc
         [%expr Sedlexing.start [%e lexbuf]]
-        (appfun (state_fun 0) [lexbuf])
+        (call_state lexbuf auto 0)
   in
-  pexp_let ~loc (gen_recflag auto) states
-    (pexp_match ~loc start_expr
-       (cases @ [case ~lhs:(ppat_any ~loc) ~guard:None ~rhs:error]))
+  let match_expr =
+    pexp_match ~loc start_expr
+      (cases @ [case ~lhs:(ppat_any ~loc) ~guard:None ~rhs:error])
+  in
+  (* [states] is empty when state 0 is an accepting sink (e.g. the pattern
+     [""]): [call_state] inlines its result above, so there are no state
+     functions to bind and [pexp_let] with no bindings would be invalid. *)
+  match states with
+    | [] -> match_expr
+    | _ -> pexp_let ~loc (gen_recflag auto) states match_expr
 
 (* Lexer specification parser *)
 

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -309,9 +309,19 @@ let call_state lexbuf (auto : Sedlex.dfa) state =
       state function (or returns the rule index for sink states).
    4. The default arm calls [backtrack] to return the last accepted rule.
    Returns [] for accepting states with no outgoing transitions (sinks). *)
-let gen_state (lexbuf_name, lexbuf) (auto : Sedlex.dfa) i
+let gen_state ~tagged (lexbuf_name, lexbuf) (auto : Sedlex.dfa) i
     { Sedlex.trans; finals; final_ops } =
   let loc = default_loc in
+  (* Blocks with [as] bindings snapshot/restore the mem cells in mark/backtrack;
+     tagless blocks skip that with the [_no_mem] variants (see sedlexing.mli). *)
+  let backtrack =
+    if tagged then [%expr Sedlexing.backtrack [%e lexbuf]]
+    else [%expr Sedlexing.__private__backtrack_no_mem [%e lexbuf]]
+  in
+  let mark i =
+    if tagged then [%expr Sedlexing.mark [%e lexbuf] [%e eint ~loc i]]
+    else [%expr Sedlexing.__private__mark_no_mem [%e lexbuf] [%e eint ~loc i]]
+  in
   let partition = Array.map (fun (cs, _, _) -> cs) trans in
   let cases =
     Array.mapi
@@ -325,13 +335,7 @@ let gen_state (lexbuf_name, lexbuf) (auto : Sedlex.dfa) i
     pexp_match ~loc
       (appfun (partition_name partition)
          [[%expr Sedlexing.__private__next_int [%e lexbuf]]])
-      (cases
-      @ [
-          case
-            ~lhs:[%pat? _]
-            ~guard:None
-            ~rhs:[%expr Sedlexing.backtrack [%e lexbuf]];
-        ])
+      (cases @ [ case ~lhs:[%pat? _] ~guard:None ~rhs:backtrack ])
   in
   let ret body =
     let lhs = pvar ~loc:lexbuf.pexp_loc lexbuf_name in
@@ -348,7 +352,7 @@ let gen_state (lexbuf_name, lexbuf) (auto : Sedlex.dfa) i
         ret
           (gen_tag_ops lexbuf final_ops
              [%expr
-               Sedlexing.mark [%e lexbuf] [%e eint ~loc i];
+               [%e mark i];
                [%e body ()]])
 
 (* [gen_recflag auto] determines whether the generated state functions need
@@ -380,10 +384,11 @@ let gen_definition ((_, lexbuf) as lexbuf_with_name)
     (compiled : Sedlex.compiled) l error =
   let loc = default_loc in
   let auto = compiled.dfa in
+  let tagged = compiled.num_tags > 0 in
   let cases =
     List.mapi (fun i (_, e) -> case ~lhs:(pint ~loc i) ~guard:None ~rhs:e) l
   in
-  let states = Array.mapi (gen_state lexbuf_with_name auto) auto in
+  let states = Array.mapi (gen_state ~tagged lexbuf_with_name auto) auto in
   let states = List.flatten (Array.to_list states) in
   let start_expr =
     if compiled.num_tags > 0 then (
@@ -396,11 +401,11 @@ let gen_definition ((_, lexbuf) as lexbuf_with_name)
         gen_tag_ops lexbuf compiled.init_tags (call_state lexbuf auto 0)
       in
       pexp_sequence ~loc
-        [%expr Sedlexing.start [%e lexbuf]]
+        [%expr Sedlexing.__private__start [%e lexbuf]]
         (pexp_sequence ~loc init_mem set_init_tags))
     else
       pexp_sequence ~loc
-        [%expr Sedlexing.start [%e lexbuf]]
+        [%expr Sedlexing.__private__start [%e lexbuf]]
         (call_state lexbuf auto 0)
   in
   let match_expr =

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -257,6 +257,11 @@ let gen_tag_ops lexbuf (ops : Sedlex.tag_op list) cont =
             [%expr
               Sedlexing.__private__set_mem_value [%e lexbuf] [%e eint ~loc cell]
                 [%e eint ~loc value];
+              [%e acc]]
+        | Copy (dst, src) ->
+            [%expr
+              Sedlexing.__private__copy_mem [%e lexbuf] [%e eint ~loc dst]
+                [%e eint ~loc src];
               [%e acc]])
     ops cont
 

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -307,10 +307,28 @@ let gen_state ~tagged (lexbuf_name, lexbuf) (auto : Sedlex.dfa) i
     else [%expr Sedlexing.__private__mark_no_mem [%e lexbuf] [%e eint ~loc i]]
   in
   let partition = Array.map (fun (cs, _, _) -> cs) trans in
+  (* Destination for a transition arm. [call_state] inlines an accepting sink
+     as a direct rule return, which is sound only when the arm advances [pos]
+     (a real character): a longer match always wins. But an arm whose set
+     contains [eof] (-1) may be taken without advancing [pos], so a direct
+     return would bypass longest-match/priority arbitration. For those, route
+     through [mark] (guarded) + [backtrack] so an equal-length, higher-priority
+     match already marked still wins. *)
+  let dest cs j =
+    let target = auto.(j) in
+    match target.Sedlex.accept with
+      | Some (r, final_ops)
+        when Cset.mem (-1) cs && Array.length target.Sedlex.trans = 0 ->
+          gen_tag_ops lexbuf final_ops
+            [%expr
+              [%e mark r];
+              [%e backtrack]]
+      | _ -> call_state lexbuf auto j
+  in
   let cases =
     Array.mapi
-      (fun i (_, j, tags) ->
-        let rhs = gen_tag_ops lexbuf tags (call_state lexbuf auto j) in
+      (fun i (cs, j, tags) ->
+        let rhs = gen_tag_ops lexbuf tags (dest cs j) in
         case ~lhs:(pint ~loc i) ~guard:None ~rhs)
       trans
   in

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -651,12 +651,14 @@ let ir_of_pattern env =
       (* Rep _ — malformed *)
       | Ppat_construct ({ txt = Lident "Rep"; _ }, _) ->
           err p.ppat_loc "the Rep operator takes 2 arguments"
-      (* Opt p — optional (zero or one) *)
+      (* Opt p — optional (zero or one). Lower as [alt r eps] (consume-first)
+         so Opt is greedy, matching Star/Plus/Rep and keeping [Opt p] and
+         [Rep (p, 0 .. 1)] equivalent under leftmost-greedy disambiguation. *)
       | Ppat_construct ({ txt = Lident "Opt"; _ }, Some (_, p)) ->
           let r =
             unwrap p.ppat_loc (Ir.reject_captures "Opt" (aux ~encoding p))
           in
-          unwrap p.ppat_loc (Ir.alt Ir.eps r)
+          unwrap p.ppat_loc (Ir.alt r Ir.eps)
       (* Compl p — complement of a character class *)
       | Ppat_construct ({ txt = Lident "Compl"; _ }, arg) -> (
           match arg with

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -227,31 +227,64 @@ let best_final final =
 
 let state_fun state = Printf.sprintf "__sedlex_state_%i" state
 
-(* [gen_tag_ops lexbuf ops cont] wraps [cont] in a sequence of tag
-   operation calls. Each [Set_position t] becomes a call to
-   [__private__set_mem_pos], and each [Set_value (cell, v)] becomes a call to
-   [__private__set_mem_value]. Operations are folded right so they execute
-   before [cont]. *)
+(* [gen_tag_ops lexbuf ops cont] wraps [cont] in the code performing the tag
+   operations [ops], which form a parallel move: every [Copy] must read its
+   source as it was before any operation of the list executed. Sources that
+   the list also writes are first saved in let-bound locals; everything else
+   compiles to direct [__private__set_mem_pos] / [__private__set_mem_value] /
+   [__private__copy_mem] calls in list order. *)
 let gen_tag_ops lexbuf (ops : Sedlex.tag_op list) cont =
   let loc = default_loc in
+  let dests =
+    List.map
+      (fun (op : Sedlex.tag_op) ->
+        match op with
+          | Copy (d, _) | Set_position d | Set_value (d, _) -> d)
+      ops
+  in
+  let clobbered =
+    List.sort_uniq compare
+      (List.filter_map
+         (fun (op : Sedlex.tag_op) ->
+           match op with
+             | Copy (_, s) when List.mem s dests -> Some s
+             | _ -> None)
+         ops)
+  in
+  let local s = Printf.sprintf "__sedlex_mem_%d" s in
+  let writes =
+    List.fold_right
+      (fun (op : Sedlex.tag_op) acc ->
+        match op with
+          | Set_position t ->
+              [%expr
+                Sedlexing.__private__set_mem_pos [%e lexbuf] [%e eint ~loc t];
+                [%e acc]]
+          | Set_value (cell, value) ->
+              [%expr
+                Sedlexing.__private__set_mem_value [%e lexbuf]
+                  [%e eint ~loc cell] [%e eint ~loc value];
+                [%e acc]]
+          | Copy (dst, src) when List.mem src clobbered ->
+              [%expr
+                Sedlexing.__private__mem_set [%e lexbuf] [%e eint ~loc dst]
+                  [%e evar ~loc (local src)];
+                [%e acc]]
+          | Copy (dst, src) ->
+              [%expr
+                Sedlexing.__private__copy_mem [%e lexbuf] [%e eint ~loc dst]
+                  [%e eint ~loc src];
+                [%e acc]])
+      ops cont
+  in
   List.fold_right
-    (fun (op : Sedlex.tag_op) acc ->
-      match op with
-        | Set_position t ->
-            [%expr
-              Sedlexing.__private__set_mem_pos [%e lexbuf] [%e eint ~loc t];
-              [%e acc]]
-        | Set_value (cell, value) ->
-            [%expr
-              Sedlexing.__private__set_mem_value [%e lexbuf] [%e eint ~loc cell]
-                [%e eint ~loc value];
-              [%e acc]]
-        | Copy (dst, src) ->
-            [%expr
-              Sedlexing.__private__copy_mem [%e lexbuf] [%e eint ~loc dst]
-                [%e eint ~loc src];
-              [%e acc]])
-    ops cont
+    (fun s acc ->
+      [%expr
+        let [%p pvar ~loc (local s)] =
+          Sedlexing.__private__mem_get [%e lexbuf] [%e eint ~loc s]
+        in
+        [%e acc]])
+    clobbered writes
 
 (* [call_state lexbuf auto state] generates the expression that transitions
    into DFA [state]. If the state has no outgoing transitions (a sink), it

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -215,16 +215,6 @@ let partition (name, p) =
 
 (* Code generation for the automata *)
 
-(* [best_final finals] returns the lowest-numbered accepting rule for this
-   state, or [None] if the state is not accepting. Lowest-numbered = highest
-   priority, matching the first-match semantics of [match%sedlex]. *)
-let best_final final =
-  let fin = ref None in
-  for i = Array.length final - 1 downto 0 do
-    if final.(i) then fin := Some i
-  done;
-  !fin
-
 let state_fun state = Printf.sprintf "__sedlex_state_%i" state
 
 (* [gen_tag_ops lexbuf ops cont] wraps [cont] in the code performing the tag
@@ -235,13 +225,7 @@ let state_fun state = Printf.sprintf "__sedlex_state_%i" state
    [__private__copy_mem] calls in list order. *)
 let gen_tag_ops lexbuf (ops : Sedlex.tag_op list) cont =
   let loc = default_loc in
-  let dests =
-    List.map
-      (fun (op : Sedlex.tag_op) ->
-        match op with
-          | Copy { dst; _ } | Set_position { dst } | Set_value { dst; _ } -> dst)
-      ops
-  in
+  let dests = List.map Sedlex.op_dest ops in
   let clobbered =
     List.sort_uniq compare
       (List.filter_map
@@ -291,18 +275,18 @@ let gen_tag_ops lexbuf (ops : Sedlex.tag_op list) cont =
    executes the state's final tag operations and returns the accepting rule
    index directly; otherwise it emits a call to the state function. *)
 let call_state lexbuf (auto : Sedlex.dfa) state =
-  let { Sedlex.trans; finals; final_ops } = auto.(state) in
+  let { Sedlex.trans; accept; _ } = auto.(state) in
   if Array.length trans = 0 then (
-    match best_final finals with
-      | Some i -> gen_tag_ops lexbuf final_ops (eint ~loc:default_loc i)
+    match accept with
+      | Some (i, ops) -> gen_tag_ops lexbuf ops (eint ~loc:default_loc i)
       | None -> assert false)
   else appfun (state_fun state) [lexbuf]
 
-(* [gen_state (lexbuf_name, lexbuf) auto i {trans; finals; final_ops}]
+(* [gen_state ~tagged (lexbuf_name, lexbuf) auto i {trans; accept; _}]
    generates the function [__sedlex_state_N] for DFA state [i]. The function:
-   1. If the state is accepting, executes [final_ops] (materializing tag
-      registers into their canonical cells) then calls [mark] to save the
-      current position and a snapshot of the memory cells.
+   1. If the state is accepting ([accept = Some (rule, final_ops)]), executes
+      [final_ops] (materializing tag registers into their canonical cells) then
+      calls [mark] to save the current position and a snapshot of memory.
    2. Reads the next code point, maps it through the partition function to
       get an equivalence class index, then pattern-matches on that index.
    3. Each transition arm executes its tag operations then calls the target
@@ -310,7 +294,7 @@ let call_state lexbuf (auto : Sedlex.dfa) state =
    4. The default arm calls [backtrack] to return the last accepted rule.
    Returns [] for accepting states with no outgoing transitions (sinks). *)
 let gen_state ~tagged (lexbuf_name, lexbuf) (auto : Sedlex.dfa) i
-    { Sedlex.trans; finals; final_ops } =
+    { Sedlex.trans; accept; _ } =
   let loc = default_loc in
   (* Blocks with [as] bindings snapshot/restore the mem cells in mark/backtrack;
      tagless blocks skip that with the [_no_mem] variants (see sedlexing.mli). *)
@@ -345,12 +329,12 @@ let gen_state ~tagged (lexbuf_name, lexbuf) (auto : Sedlex.dfa) i
         ~expr:(Exp.fun_ ~loc Nolabel None lhs body);
     ]
   in
-  match best_final finals with
+  match accept with
     | None -> ret (body ())
     | Some _ when Array.length trans = 0 -> []
-    | Some i ->
+    | Some (i, ops) ->
         ret
-          (gen_tag_ops lexbuf final_ops
+          (gen_tag_ops lexbuf ops
              [%expr
                [%e mark i];
                [%e body ()]])

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -227,18 +227,6 @@ let best_final final =
 
 let state_fun state = Printf.sprintf "__sedlex_state_%i" state
 
-(* [call_state lexbuf auto state] generates the expression that transitions
-   into DFA [state]. If the state has no outgoing transitions (a sink), it
-   returns the accepting rule index directly; otherwise it emits a function
-   call to the generated state function. *)
-let call_state lexbuf (auto : Sedlex.dfa) state =
-  let { Sedlex.trans; finals } = auto.(state) in
-  if Array.length trans = 0 then (
-    match best_final finals with
-      | Some i -> eint ~loc:default_loc i
-      | None -> assert false)
-  else appfun (state_fun state) [lexbuf]
-
 (* [gen_tag_ops lexbuf ops cont] wraps [cont] in a sequence of tag
    operation calls. Each [Set_position t] becomes a call to
    [__private__set_mem_pos], and each [Set_value (cell, v)] becomes a call to
@@ -265,9 +253,23 @@ let gen_tag_ops lexbuf (ops : Sedlex.tag_op list) cont =
               [%e acc]])
     ops cont
 
-(* [gen_state (lexbuf_name, lexbuf) auto i {trans; finals}] generates the
-   function [__sedlex_state_N] for DFA state [i]. The function:
-   1. If the state is accepting, calls [mark] to save the current position.
+(* [call_state lexbuf auto state] generates the expression that transitions
+   into DFA [state]. If the state has no outgoing transitions (a sink), it
+   executes the state's final tag operations and returns the accepting rule
+   index directly; otherwise it emits a call to the state function. *)
+let call_state lexbuf (auto : Sedlex.dfa) state =
+  let { Sedlex.trans; finals; final_ops } = auto.(state) in
+  if Array.length trans = 0 then (
+    match best_final finals with
+      | Some i -> gen_tag_ops lexbuf final_ops (eint ~loc:default_loc i)
+      | None -> assert false)
+  else appfun (state_fun state) [lexbuf]
+
+(* [gen_state (lexbuf_name, lexbuf) auto i {trans; finals; final_ops}]
+   generates the function [__sedlex_state_N] for DFA state [i]. The function:
+   1. If the state is accepting, executes [final_ops] (materializing tag
+      registers into their canonical cells) then calls [mark] to save the
+      current position and a snapshot of the memory cells.
    2. Reads the next code point, maps it through the partition function to
       get an equivalence class index, then pattern-matches on that index.
    3. Each transition arm executes its tag operations then calls the target
@@ -275,7 +277,7 @@ let gen_tag_ops lexbuf (ops : Sedlex.tag_op list) cont =
    4. The default arm calls [backtrack] to return the last accepted rule.
    Returns [] for accepting states with no outgoing transitions (sinks). *)
 let gen_state (lexbuf_name, lexbuf) (auto : Sedlex.dfa) i
-    { Sedlex.trans; finals } =
+    { Sedlex.trans; finals; final_ops } =
   let loc = default_loc in
   let partition = Array.map (fun (cs, _, _) -> cs) trans in
   let cases =
@@ -311,9 +313,10 @@ let gen_state (lexbuf_name, lexbuf) (auto : Sedlex.dfa) i
     | Some _ when Array.length trans = 0 -> []
     | Some i ->
         ret
-          [%expr
-            Sedlexing.mark [%e lexbuf] [%e eint ~loc i];
-            [%e body ()]]
+          (gen_tag_ops lexbuf final_ops
+             [%expr
+               Sedlexing.mark [%e lexbuf] [%e eint ~loc i];
+               [%e body ()]])
 
 (* [gen_recflag auto] determines whether the generated state functions need
    [let rec]. If every transition leads to a sink state (no further

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -238,8 +238,7 @@ let gen_tag_ops lexbuf (ops : Sedlex.tag_op list) cont =
   let dests =
     List.map
       (fun (op : Sedlex.tag_op) ->
-        match op with
-          | Copy (d, _) | Set_position d | Set_value (d, _) -> d)
+        match op with Copy (d, _) | Set_position d | Set_value (d, _) -> d)
       ops
   in
   let clobbered =

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -1371,13 +1371,15 @@ let%expect_test "as_bindings_num_mem_cells" =
     | _ -> assert false);
   [%expect {| mem_cells=0 |}];
   (* Or-pattern with different offsets: positions are known, so only the
-     discriminator needs memory — its canonical cell plus a working register *)
+     discriminator cell is needed (conflict-free: a branch's discriminator
+     fires just before its final node, so its holder never survives into a
+     state where the other branch writes) *)
   let buf = Sedlexing.Utf8.from_string "abcdef" in
   (match%sedlex buf with
     | ("abc" as _x), "def" | "a", ("bcd" as _x), "ey" ->
         Printf.printf "mem_cells=%d\n" (num_mem buf)
     | _ -> assert false);
-  [%expect {| mem_cells=2 |}]
+  [%expect {| mem_cells=1 |}]
 
 let%expect_test "as_bindings_multi_rule_mem_cells" =
   (* All rules in a match%sedlex share one pool of memory cells.

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -1381,6 +1381,37 @@ let%expect_test "empty_pattern" =
     empty
     |}]
 
+let%expect_test "eof_rule_priority" =
+  (* An earlier rule and a later eof-terminated rule match the same lexeme
+     length; declaration order must break the tie, even though eof's zero-width
+     accept is reached last. Exercises the generated runtime, not just the DFA
+     interpreter. *)
+  let lex buf =
+    match%sedlex buf with
+    | Plus ('b' | 'c') -> "rule0"
+    | (Star ('a' .. 'c')), eof -> "rule1"
+    | _ -> "none"
+  in
+  let lex_eof_first buf =
+    match%sedlex buf with
+    | (Star ('a' .. 'c')), eof -> "rule0"
+    | Plus ('b' | 'c') -> "rule1"
+    | _ -> "none"
+  in
+  List.iter
+    (fun s ->
+      Printf.printf "%-4S -> %-5s | %s\n" s
+        (lex (Sedlexing.Utf8.from_string s))
+        (lex_eof_first (Sedlexing.Utf8.from_string s)))
+    [ "cc"; "c"; ""; "a" ];
+  [%expect
+    {|
+    "cc" -> rule0 | rule0
+    "c"  -> rule0 | rule0
+    ""   -> rule1 | rule0
+    "a"  -> rule1 | rule0
+    |}]
+
 let num_mem buf = Sedlexing.__private__num_mem_cells buf
 
 let%expect_test "as_bindings_num_mem_cells" =

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -1346,6 +1346,26 @@ let%expect_test "opt_greedy" =
     | _ -> assert false);
   [%expect {| rep x="" |}]
 
+let%expect_test "rep_1_1_char_ops" =
+  (* Rep (_, 1 .. 1) is a single-character regexp, so Compl/Sub/Intersect
+     accept it: it normalizes to the bare Chars node, as repeat r (1, 1) did
+     on master. *)
+  let buf = Sedlexing.Utf8.from_string "b" in
+  (match%sedlex buf with
+    | Compl (Rep ('a', 1 .. 1)) -> print_string "compl-ok\n"
+    | _ -> assert false);
+  [%expect {| compl-ok |}];
+  let buf = Sedlexing.Utf8.from_string "b" in
+  (match%sedlex buf with
+    | Sub (any, Rep ('a', 1 .. 1)) -> print_string "sub-ok\n"
+    | _ -> assert false);
+  [%expect {| sub-ok |}];
+  let buf = Sedlexing.Utf8.from_string "a" in
+  (match%sedlex buf with
+    | Intersect ('a' .. 'c', Rep ('a', 1 .. 1)) -> print_string "inter-ok\n"
+    | _ -> assert false);
+  [%expect {| inter-ok |}]
+
 let num_mem buf = Sedlexing.__private__num_mem_cells buf
 
 let%expect_test "as_bindings_num_mem_cells" =

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -1329,6 +1329,23 @@ let%expect_test "as_bindings" =
     | _ -> assert false);
   [%expect {| x=a y=ba |}]
 
+let%expect_test "opt_greedy" =
+  (* Opt is greedy (consume-first), so it agrees with Rep (_, 0 .. 1): when the
+     empty parse and the consuming parse have the same total length, both let
+     the leading optional take the character, leaving the trailing Star empty. *)
+  let buf = Sedlexing.Utf8.from_string "a" in
+  (match%sedlex buf with
+    | Opt 'a', (Star 'a' as x) ->
+        Printf.printf "opt x=%S\n" (Sedlexing.Utf8.of_submatch x)
+    | _ -> assert false);
+  [%expect {| opt x="" |}];
+  let buf = Sedlexing.Utf8.from_string "a" in
+  (match%sedlex buf with
+    | Rep ('a', 0 .. 1), (Star 'a' as x) ->
+        Printf.printf "rep x=%S\n" (Sedlexing.Utf8.of_submatch x)
+    | _ -> assert false);
+  [%expect {| rep x="" |}]
+
 let num_mem buf = Sedlexing.__private__num_mem_cells buf
 
 let%expect_test "as_bindings_num_mem_cells" =

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -1366,6 +1366,21 @@ let%expect_test "rep_1_1_char_ops" =
     | _ -> assert false);
   [%expect {| inter-ok |}]
 
+let%expect_test "empty_pattern" =
+  (* A nullable-only rule makes DFA state 0 an accepting sink; the generated
+     code must not emit an empty `let rec` or call an undefined state function.
+     [""] matches the zero-length prefix at position 0 regardless of input. *)
+  let lex buf =
+    match%sedlex buf with "" -> "empty" | _ -> "other"
+  in
+  Printf.printf "%s\n" (lex (Sedlexing.Utf8.from_string ""));
+  Printf.printf "%s\n" (lex (Sedlexing.Utf8.from_string "abc"));
+  [%expect
+    {|
+    empty
+    empty
+    |}]
+
 let num_mem buf = Sedlexing.__private__num_mem_cells buf
 
 let%expect_test "as_bindings_num_mem_cells" =

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -1370,13 +1370,14 @@ let%expect_test "as_bindings_num_mem_cells" =
         Printf.printf "mem_cells=%d\n" (num_mem buf)
     | _ -> assert false);
   [%expect {| mem_cells=0 |}];
-  (* Or-pattern with different offsets: 1 cell (disc only, positions known) *)
+  (* Or-pattern with different offsets: positions are known, so only the
+     discriminator needs memory — its canonical cell plus a working register *)
   let buf = Sedlexing.Utf8.from_string "abcdef" in
   (match%sedlex buf with
     | ("abc" as _x), "def" | "a", ("bcd" as _x), "ey" ->
         Printf.printf "mem_cells=%d\n" (num_mem buf)
     | _ -> assert false);
-  [%expect {| mem_cells=1 |}]
+  [%expect {| mem_cells=2 |}]
 
 let%expect_test "as_bindings_multi_rule_mem_cells" =
   (* All rules in a match%sedlex share one pool of memory cells.

--- a/test/codegen/test_gen.ml
+++ b/test/codegen/test_gen.ml
@@ -24,16 +24,18 @@ let%expect_test "simple string match" =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
       | 1 -> __sedlex_state_2 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
       | 0 -> 0
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
       | 0 -> 0
-      | _ -> Sedlexing.backtrack buf in
-    match Sedlexing.start buf; __sedlex_state_0 buf with | 0 -> () | _ -> ()
+      | _ -> Sedlexing.__private__backtrack_no_mem buf in
+    match Sedlexing.__private__start buf; __sedlex_state_0 buf with
+    | 0 -> ()
+    | _ -> ()
     |}]
 
 let%expect_test "character class" =
@@ -57,13 +59,15 @@ let%expect_test "character class" =
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_1 buf =
-      Sedlexing.mark buf 0;
+      Sedlexing.__private__mark_no_mem buf 0;
       (match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_1 buf
-       | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf; __sedlex_state_0 buf with | 0 -> () | _ -> ()
+       | _ -> Sedlexing.__private__backtrack_no_mem buf) in
+    match Sedlexing.__private__start buf; __sedlex_state_0 buf with
+    | 0 -> ()
+    | _ -> ()
     |}]
 
 let%expect_test "multi-rule" =
@@ -101,21 +105,21 @@ let%expect_test "multi-rule" =
       | 0 -> __sedlex_state_3 buf
       | 1 -> __sedlex_state_1 buf
       | 2 -> __sedlex_state_2 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
       | 0 -> 0
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
       | 0 -> 1
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_3 buf =
-      Sedlexing.mark buf 2;
+      Sedlexing.__private__mark_no_mem buf 2;
       (match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_3 buf
-       | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf; __sedlex_state_0 buf with
+       | _ -> Sedlexing.__private__backtrack_no_mem buf) in
+    match Sedlexing.__private__start buf; __sedlex_state_0 buf with
     | 0 -> ()
     | 1 -> ()
     | 2 -> ()
@@ -146,16 +150,16 @@ let%expect_test "as binding: simple" =
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_2 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
       | 0 -> 0
-      | _ -> Sedlexing.backtrack buf in
-    match Sedlexing.start buf; __sedlex_state_0 buf with
+      | _ -> Sedlexing.__private__backtrack_no_mem buf in
+    match Sedlexing.__private__start buf; __sedlex_state_0 buf with
     | 0 ->
         let x =
           let __s = 1 in
@@ -213,7 +217,7 @@ let%expect_test "as binding: simple, no static elimination" =
       (match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_3 buf
        | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 2;
           __sedlex_state_0 buf
     with
@@ -247,13 +251,13 @@ let%expect_test "as binding: whole-match shortcut" =
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_1 buf =
-      Sedlexing.mark buf 0;
+      Sedlexing.__private__mark_no_mem buf 0;
       (match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_1 buf
-       | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf; __sedlex_state_0 buf with
+       | _ -> Sedlexing.__private__backtrack_no_mem buf) in
+    match Sedlexing.__private__start buf; __sedlex_state_0 buf with
     | 0 ->
         let x =
           let __s = 0 in
@@ -289,16 +293,16 @@ let%expect_test "as binding: multiple bindings" =
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_2 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
       | 0 -> 0
-      | _ -> Sedlexing.backtrack buf in
-    match Sedlexing.start buf; __sedlex_state_0 buf with
+      | _ -> Sedlexing.__private__backtrack_no_mem buf in
+    match Sedlexing.__private__start buf; __sedlex_state_0 buf with
     | 0 ->
         let x =
           let __s = 0 in
@@ -358,7 +362,7 @@ let%expect_test "as binding: multiple bindings, no static elimination" =
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_3 buf
        | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
@@ -434,7 +438,7 @@ let%expect_test
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> (Sedlexing.__private__set_mem_value buf 2 1; __sedlex_state_4 buf)
        | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 3;
           __sedlex_state_0 buf
     with
@@ -508,7 +512,7 @@ let%expect_test "as binding: shared prefix or-pattern" =
       | 0 -> (Sedlexing.__private__set_mem_value buf 0 0; 0)
       | 1 -> (Sedlexing.__private__set_mem_value buf 0 1; 0)
       | _ -> Sedlexing.backtrack buf in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
@@ -577,7 +581,7 @@ let%expect_test "as binding: 3-way or reuses disc cell" =
       (match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
        | 0 -> (Sedlexing.__private__set_mem_value buf 0 0; 0)
        | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
@@ -632,16 +636,16 @@ let%expect_test "as binding: multi-rule" =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
       | 1 -> __sedlex_state_2 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
       | 0 -> 0
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
       | 0 -> 1
-      | _ -> Sedlexing.backtrack buf in
-    match Sedlexing.start buf; __sedlex_state_0 buf with
+      | _ -> Sedlexing.__private__backtrack_no_mem buf in
+    match Sedlexing.__private__start buf; __sedlex_state_0 buf with
     | 0 ->
         let x =
           let __s = 1 in
@@ -702,7 +706,7 @@ let%expect_test "as binding: multi-rule, no static elimination" =
       (match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_3 buf
        | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
@@ -738,12 +742,12 @@ let%expect_test "as binding: wrapping alternation" =
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
       | 0 -> 0
-      | _ -> Sedlexing.backtrack buf in
-    match Sedlexing.start buf; __sedlex_state_0 buf with
+      | _ -> Sedlexing.__private__backtrack_no_mem buf in
+    match Sedlexing.__private__start buf; __sedlex_state_0 buf with
     | 0 ->
         let y =
           let __s = 1 in
@@ -806,7 +810,7 @@ let%expect_test "as binding: wrapping alternation, no static elimination" =
       (match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_4 buf
        | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
@@ -872,7 +876,7 @@ let%expect_test "optim: element-length (Offset_from_tag)" =
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_3 buf
        | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
@@ -918,18 +922,18 @@ let%expect_test "optim: or-pattern offset propagation" =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
       | 1 -> __sedlex_state_2 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_1 buf =
-      Sedlexing.mark buf 0;
+      Sedlexing.__private__mark_no_mem buf 0;
       (match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_1 buf
-       | _ -> Sedlexing.backtrack buf)
+       | _ -> Sedlexing.__private__backtrack_no_mem buf)
     and __sedlex_state_2 buf =
-      Sedlexing.mark buf 0;
+      Sedlexing.__private__mark_no_mem buf 0;
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_2 buf
-       | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf; __sedlex_state_0 buf with
+       | _ -> Sedlexing.__private__backtrack_no_mem buf) in
+    match Sedlexing.__private__start buf; __sedlex_state_0 buf with
     | 0 ->
         let x =
           let __s = 0 in
@@ -971,18 +975,18 @@ let%expect_test "optim: discriminator elision" =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
       | 1 -> __sedlex_state_2 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_1 buf =
-      Sedlexing.mark buf 0;
+      Sedlexing.__private__mark_no_mem buf 0;
       (match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_1 buf
-       | _ -> Sedlexing.backtrack buf)
+       | _ -> Sedlexing.__private__backtrack_no_mem buf)
     and __sedlex_state_2 buf =
-      Sedlexing.mark buf 0;
+      Sedlexing.__private__mark_no_mem buf 0;
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_2 buf
-       | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf; __sedlex_state_0 buf with
+       | _ -> Sedlexing.__private__backtrack_no_mem buf) in
+    match Sedlexing.__private__start buf; __sedlex_state_0 buf with
     | 0 ->
         let x =
           let __s = 0 in
@@ -1034,7 +1038,7 @@ let%expect_test "optim: intra-rule tag coalescing" =
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_2 buf
        | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
@@ -1129,7 +1133,7 @@ let%expect_test "optim: cross-rule cell sharing" =
       (match __sedlex_partition_7 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_6 buf
        | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 4;
           __sedlex_state_0 buf
     with
@@ -1199,7 +1203,7 @@ let%expect_test "optim: dead tag elimination" =
       | 1 -> 0
       | 2 -> 1
       | _ -> Sedlexing.backtrack buf in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
@@ -1262,7 +1266,7 @@ let%expect_test "conflicted tag: star before overlapping capture" =
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_2 buf
        | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 3;
           Sedlexing.__private__set_mem_pos buf 1;
           __sedlex_state_0 buf
@@ -1316,7 +1320,7 @@ let%expect_test "optim: self-loop tag delay" =
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_2 buf
        | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
@@ -1361,17 +1365,17 @@ let%expect_test "optim: tag remapping after coalescing" =
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_2 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_2 buf
       | 1 -> 0
-      | _ -> Sedlexing.backtrack buf in
-    match Sedlexing.start buf; __sedlex_state_0 buf with
+      | _ -> Sedlexing.__private__backtrack_no_mem buf in
+    match Sedlexing.__private__start buf; __sedlex_state_0 buf with
     | 0 ->
         let x =
           let __s = 0 in
@@ -1433,7 +1437,7 @@ let%expect_test "optim: set_prev with backtracking" =
        | 0 -> 0
        | 1 -> __sedlex_state_2 buf
        | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
@@ -1482,25 +1486,25 @@ let%expect_test "Rep fixed-length prefix enables Start_plus" =
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_2 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_2 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_3 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_3 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_4 buf
-      | _ -> Sedlexing.backtrack buf
+      | _ -> Sedlexing.__private__backtrack_no_mem buf
     and __sedlex_state_4 buf =
-      Sedlexing.mark buf 0;
+      Sedlexing.__private__mark_no_mem buf 0;
       (match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_4 buf
-       | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf; __sedlex_state_0 buf with
+       | _ -> Sedlexing.__private__backtrack_no_mem buf) in
+    match Sedlexing.__private__start buf; __sedlex_state_0 buf with
     | 0 ->
         let x =
           let __s = 3 in
@@ -1562,7 +1566,7 @@ let%expect_test "Rep variable-length prefix forces a tag" =
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_4 buf
        | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
@@ -1660,7 +1664,7 @@ let%expect_test "as binding: or-chain then nested or on right" =
       match __sedlex_partition_7 (Sedlexing.__private__next_int buf) with
       | 0 -> (Sedlexing.__private__set_mem_value buf 1 2; 0)
       | _ -> Sedlexing.backtrack buf in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 2;
           __sedlex_state_0 buf
     with

--- a/test/codegen/test_gen.ml
+++ b/test/codegen/test_gen.ml
@@ -172,7 +172,8 @@ let%expect_test "as binding: simple, no static elimination" =
   (match%sedlex_test buf with
     | Plus 'a', (Plus 'b' as x), Plus 'c' -> ignore x
     | _ -> ());
-  [%expect {|
+  [%expect
+    {|
     DOT:
     digraph {
       rankdir=LR;
@@ -318,7 +319,8 @@ let%expect_test "as binding: multiple bindings, no static elimination" =
   (match%sedlex_test buf with
     | (Plus 'a' as x), '-', (Plus 'b' as y) -> ignore (x, y)
     | _ -> ());
-  [%expect {|
+  [%expect
+    {|
     DOT:
     digraph {
       rankdir=LR;
@@ -377,12 +379,13 @@ let%expect_test "as binding: multiple bindings, no static elimination" =
    cannot be derived statically: each branch allocates a real position
    tag for x, and the branches get distinct discriminator values so
    extraction can pick the right tag at runtime. *)
-let%expect_test "as binding: or-pattern with discriminator, no static \
-                 elimination" =
+let%expect_test
+    "as binding: or-pattern with discriminator, no static elimination" =
   (match%sedlex_test buf with
-    | (Plus 'a', (Plus 'b' as x)) | ((Plus 'b' as x), Plus 'a') -> ignore x
+    | Plus 'a', (Plus 'b' as x) | (Plus 'b' as x), Plus 'a' -> ignore x
     | _ -> ());
-  [%expect {|
+  [%expect
+    {|
     DOT:
     digraph {
       rankdir=LR;
@@ -657,7 +660,8 @@ let%expect_test "as binding: multi-rule, no static elimination" =
     | Plus 'a', (Plus 'b' as x) -> ignore x
     | "cd" -> ()
     | _ -> ());
-  [%expect {|
+  [%expect
+    {|
     DOT:
     digraph {
       rankdir=LR;
@@ -757,7 +761,8 @@ let%expect_test "as binding: wrapping alternation, no static elimination" =
   (match%sedlex_test buf with
     | 'x', (("ab" | "c") as y), Plus 'z' -> ignore y
     | _ -> ());
-  [%expect {|
+  [%expect
+    {|
     DOT:
     digraph {
       rankdir=LR;
@@ -1219,7 +1224,8 @@ let%expect_test "conflicted tag: star before overlapping capture" =
   (match%sedlex_test buf with
     | Star 'a', (('a', Plus 'b') as x) -> ignore x
     | _ -> ());
-  [%expect {|
+  [%expect
+    {|
     DOT:
     digraph {
       rankdir=LR;
@@ -1511,7 +1517,8 @@ let%expect_test "Rep variable-length prefix forces a tag" =
   (match%sedlex_test buf with
     | Rep ('0' .. '9', 2 .. 3), (Plus 'a' .. 'z' as x) -> ignore x
     | _ -> ());
-  [%expect {|
+  [%expect
+    {|
     DOT:
     digraph {
       rankdir=LR;

--- a/test/codegen/test_gen.ml
+++ b/test/codegen/test_gen.ml
@@ -165,6 +165,66 @@ let%expect_test "as binding: simple" =
     | _ -> ()
     |}]
 
+(* Counterpart of "as binding: simple" where no boundary is statically
+   known: variable-length context on both sides and a variable-length
+   capture force both a start and an end tag. *)
+let%expect_test "as binding: simple, no static elimination" =
+  (match%sedlex_test buf with
+    | Plus 'a', (Plus 'b' as x), Plus 'c' -> ignore x
+    | _ -> ());
+  [%expect {|
+    DOT:
+    digraph {
+      rankdir=LR;
+      node [shape=circle];
+
+      _start [shape=point];
+      _start -> state0;
+
+      state0 [label="0"];
+      state0 -> state1 [label="'a' {t0}"];
+      state1 [label="1"];
+      state1 -> state1 [label="'a' {t0}"];
+      state1 -> state2 [label="'b' {t1}"];
+      state2 [label="2"];
+      state2 -> state2 [label="'b' {t1}"];
+      state2 -> state3 [label="'c'"];
+      state3 [label="3\n[rule 0]", shape=doublecircle];
+      state3 -> state3 [label="'c'"];
+    }
+    CODE:
+    let rec __sedlex_state_0 buf =
+      match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_1 buf =
+      match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_2 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_2 buf =
+      match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_2 buf)
+      | 1 -> __sedlex_state_3 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_3 buf =
+      Sedlexing.mark buf 0;
+      (match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
+       | 0 -> __sedlex_state_3 buf
+       | _ -> Sedlexing.backtrack buf) in
+    match Sedlexing.start buf;
+          Sedlexing.__private__init_mem buf 2;
+          __sedlex_state_0 buf
+    with
+    | 0 ->
+        let x =
+          let __s = Sedlexing.__private__mem_pos buf 0 in
+          let __e = Sedlexing.__private__mem_pos buf 1 in
+          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+        ignore x
+    | _ -> ()
+    |}]
+
 let%expect_test "as binding: whole-match shortcut" =
   (match%sedlex_test buf with Plus 'a' .. 'z' as x -> ignore x | _ -> ());
   [%expect
@@ -251,6 +311,68 @@ let%expect_test "as binding: multiple bindings" =
     | _ -> ()
     |}]
 
+(* Counterpart of "as binding: multiple bindings" where lengths are not
+   static: x needs an end tag, and y's start is anchored off that same
+   tag (Tag + 1) via the left-context fallback in Seq lowering. *)
+let%expect_test "as binding: multiple bindings, no static elimination" =
+  (match%sedlex_test buf with
+    | (Plus 'a' as x), '-', (Plus 'b' as y) -> ignore (x, y)
+    | _ -> ());
+  [%expect {|
+    DOT:
+    digraph {
+      rankdir=LR;
+      node [shape=circle];
+
+      _start [shape=point];
+      _start -> state0;
+
+      state0 [label="0"];
+      state0 -> state1 [label="'a' {t0}"];
+      state1 [label="1"];
+      state1 -> state2 [label="'-'"];
+      state1 -> state1 [label="'a' {t0}"];
+      state2 [label="2"];
+      state2 -> state3 [label="'b'"];
+      state3 [label="3\n[rule 0]", shape=doublecircle];
+      state3 -> state3 [label="'b'"];
+    }
+    CODE:
+    let rec __sedlex_state_0 buf =
+      match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_1 buf =
+      match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_2 buf
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_2 buf =
+      match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_3 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_3 buf =
+      Sedlexing.mark buf 0;
+      (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
+       | 0 -> __sedlex_state_3 buf
+       | _ -> Sedlexing.backtrack buf) in
+    match Sedlexing.start buf;
+          Sedlexing.__private__init_mem buf 1;
+          __sedlex_state_0 buf
+    with
+    | 0 ->
+        let x =
+          let __s = 0 in
+          let __e = Sedlexing.__private__mem_pos buf 0 in
+          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+        let y =
+          let __s = (Sedlexing.__private__mem_pos buf 0) + 1 in
+          let __e = Sedlexing.lexeme_length buf in
+          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+        ignore (x, y)
+    | _ -> ()
+    |}]
+
 let%expect_test "as binding: or-pattern with discriminator" =
   (match%sedlex_test buf with
     | (Plus '0' .. '9' as x) | (Plus 'a' .. 'z' as x) -> ignore x
@@ -295,6 +417,83 @@ let%expect_test "as binding: or-pattern with discriminator" =
           let __s = 0 in
           let __e = Sedlexing.lexeme_length buf in
           { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+        ignore x
+    | _ -> ()
+    |}]
+
+(* Counterpart of "as binding: or-pattern with discriminator" where the
+   positions cannot be derived statically: each branch allocates a real
+   position tag for x, and the branches get distinct discriminator values
+   so extraction can pick the right tag at runtime. *)
+let%expect_test "as binding: or-pattern with discriminator, no static \
+                 elimination" =
+  (match%sedlex_test buf with
+    | (Plus 'a', (Plus 'b' as x)) | ((Plus 'b' as x), Plus 'a') -> ignore x
+    | _ -> ());
+  [%expect {|
+    DOT:
+    digraph {
+      rankdir=LR;
+      node [shape=circle];
+
+      _start [shape=point];
+      _start -> state0;
+
+      state0 [label="0"];
+      state0 -> state1 [label="'a' {t0}"];
+      state0 -> state2 [label="'b' {t1}"];
+      state1 [label="1"];
+      state1 -> state1 [label="'a' {t0}"];
+      state1 -> state3 [label="'b' {d2=0}"];
+      state2 [label="2"];
+      state2 -> state4 [label="'a' {d2=1}"];
+      state2 -> state2 [label="'b' {t1}"];
+      state3 [label="3\n[rule 0]", shape=doublecircle];
+      state3 -> state3 [label="'b' {d2=0}"];
+      state4 [label="4\n[rule 0]", shape=doublecircle];
+      state4 -> state4 [label="'a' {d2=1}"];
+    }
+    CODE:
+    let rec __sedlex_state_0 buf =
+      match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_2 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_1 buf =
+      match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 1 -> (Sedlexing.__private__set_mem_value buf 2 0; __sedlex_state_3 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_2 buf =
+      match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_value buf 2 1; __sedlex_state_4 buf)
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_2 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_3 buf =
+      Sedlexing.mark buf 0;
+      (match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
+       | 0 -> (Sedlexing.__private__set_mem_value buf 2 0; __sedlex_state_3 buf)
+       | _ -> Sedlexing.backtrack buf)
+    and __sedlex_state_4 buf =
+      Sedlexing.mark buf 0;
+      (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
+       | 0 -> (Sedlexing.__private__set_mem_value buf 2 1; __sedlex_state_4 buf)
+       | _ -> Sedlexing.backtrack buf) in
+    match Sedlexing.start buf;
+          Sedlexing.__private__init_mem buf 3;
+          __sedlex_state_0 buf
+    with
+    | 0 ->
+        let x =
+          if (Sedlexing.__private__mem_value buf 2) = 0
+          then
+            let __s = Sedlexing.__private__mem_pos buf 0 in
+            let __e = Sedlexing.lexeme_length buf in
+            { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) }
+          else
+            (let __s = 0 in
+             let __e = Sedlexing.__private__mem_pos buf 1 in
+             { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) }) in
         ignore x
     | _ -> ()
     |}]
@@ -498,6 +697,69 @@ let%expect_test "as binding: multi-rule" =
     | _ -> ()
     |}]
 
+(* Counterpart of "as binding: multi-rule" where the capture's start is
+   not statically known: the variable-length prefix forces a start tag,
+   while the untagged second rule shares the DFA. *)
+let%expect_test "as binding: multi-rule, no static elimination" =
+  (match%sedlex_test buf with
+    | Plus 'a', (Plus 'b' as x) -> ignore x
+    | "cd" -> ()
+    | _ -> ());
+  [%expect {|
+    DOT:
+    digraph {
+      rankdir=LR;
+      node [shape=circle];
+
+      _start [shape=point];
+      _start -> state0;
+
+      state0 [label="0"];
+      state0 -> state1 [label="'a' {t0}"];
+      state0 -> state2 [label="'c'"];
+      state1 [label="1"];
+      state1 -> state1 [label="'a' {t0}"];
+      state1 -> state3 [label="'b'"];
+      state2 [label="2"];
+      state2 -> state4 [label="'d'"];
+      state3 [label="3\n[rule 0]", shape=doublecircle];
+      state3 -> state3 [label="'b'"];
+      state4 [label="4\n[rule 1]", shape=doublecircle];
+    }
+    CODE:
+    let rec __sedlex_state_0 buf =
+      match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 1 -> __sedlex_state_2 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_1 buf =
+      match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 1 -> __sedlex_state_3 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_2 buf =
+      match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
+      | 0 -> 1
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_3 buf =
+      Sedlexing.mark buf 0;
+      (match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
+       | 0 -> __sedlex_state_3 buf
+       | _ -> Sedlexing.backtrack buf) in
+    match Sedlexing.start buf;
+          Sedlexing.__private__init_mem buf 1;
+          __sedlex_state_0 buf
+    with
+    | 0 ->
+        let x =
+          let __s = Sedlexing.__private__mem_pos buf 0 in
+          let __e = Sedlexing.lexeme_length buf in
+          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+        ignore x
+    | 1 -> ()
+    | _ -> ()
+    |}]
+
 let%expect_test "as binding: wrapping alternation" =
   (match%sedlex_test buf with 'x', (('a' | 'b') as y) -> ignore y | _ -> ());
   [%expect
@@ -530,6 +792,71 @@ let%expect_test "as binding: wrapping alternation" =
         let y =
           let __s = 1 in
           let __e = Sedlexing.lexeme_length buf in
+          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+        ignore y
+    | _ -> ()
+    |}]
+
+(* Counterpart of "as binding: wrapping alternation" where the wrapped
+   alternation has branches of different lengths and a variable-length
+   suffix follows: the capture's end cannot be computed statically and
+   needs an end tag. *)
+let%expect_test "as binding: wrapping alternation, no static elimination" =
+  (match%sedlex_test buf with
+    | 'x', (("ab" | "c") as y), Plus 'z' -> ignore y
+    | _ -> ());
+  [%expect {|
+    DOT:
+    digraph {
+      rankdir=LR;
+      node [shape=circle];
+
+      _start [shape=point];
+      _start -> state0;
+
+      state0 [label="0"];
+      state0 -> state1 [label="'x'"];
+      state1 [label="1"];
+      state1 -> state2 [label="'a'"];
+      state1 -> state3 [label="'c' {t0}"];
+      state2 [label="2"];
+      state2 -> state3 [label="'b' {t0}"];
+      state3 [label="3"];
+      state3 -> state4 [label="'z'"];
+      state4 [label="4\n[rule 0]", shape=doublecircle];
+      state4 -> state4 [label="'z'"];
+    }
+    CODE:
+    let rec __sedlex_state_0 buf =
+      match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_1 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_1 buf =
+      match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_2 buf
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_3 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_2 buf =
+      match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_3 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_3 buf =
+      match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_4 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_4 buf =
+      Sedlexing.mark buf 0;
+      (match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
+       | 0 -> __sedlex_state_4 buf
+       | _ -> Sedlexing.backtrack buf) in
+    match Sedlexing.start buf;
+          Sedlexing.__private__init_mem buf 1;
+          __sedlex_state_0 buf
+    with
+    | 0 ->
+        let y =
+          let __s = 1 in
+          let __e = Sedlexing.__private__mem_pos buf 0 in
           { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         ignore y
     | _ -> ()
@@ -1219,6 +1546,70 @@ let%expect_test "Rep fixed-length prefix enables Start_plus" =
     | 0 ->
         let x =
           let __s = 3 in
+          let __e = Sedlexing.lexeme_length buf in
+          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+        ignore x
+    | _ -> ()
+    |}]
+
+(* Counterpart of "Rep fixed-length prefix enables Start_plus": a Rep
+   with a variable range (2..3) has no fixed length, so the capture's
+   start needs a tag. *)
+let%expect_test "Rep variable-length prefix forces a tag" =
+  (match%sedlex_test buf with
+    | Rep ('0' .. '9', 2 .. 3), (Plus 'a' .. 'z' as x) -> ignore x
+    | _ -> ());
+  [%expect {|
+    DOT:
+    digraph {
+      rankdir=LR;
+      node [shape=circle];
+
+      _start [shape=point];
+      _start -> state0;
+
+      state0 [label="0"];
+      state0 -> state1 [label="'0'-'9'"];
+      state1 [label="1"];
+      state1 -> state2 [label="'0'-'9' {t0}"];
+      state2 [label="2"];
+      state2 -> state3 [label="'0'-'9' {t0}"];
+      state2 -> state4 [label="'a'-'z'"];
+      state3 [label="3"];
+      state3 -> state4 [label="'a'-'z'"];
+      state4 [label="4\n[rule 0]", shape=doublecircle];
+      state4 -> state4 [label="'a'-'z'"];
+    }
+    CODE:
+    let rec __sedlex_state_0 buf =
+      match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_1 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_1 buf =
+      match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_2 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_2 buf =
+      match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_3 buf)
+      | 1 -> __sedlex_state_4 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_3 buf =
+      match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_4 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_4 buf =
+      Sedlexing.mark buf 0;
+      (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
+       | 0 -> __sedlex_state_4 buf
+       | _ -> Sedlexing.backtrack buf) in
+    match Sedlexing.start buf;
+          Sedlexing.__private__init_mem buf 1;
+          __sedlex_state_0 buf
+    with
+    | 0 ->
+        let x =
+          let __s = Sedlexing.__private__mem_pos buf 0 in
           let __e = Sedlexing.lexeme_length buf in
           { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
         ignore x

--- a/test/codegen/test_gen.ml
+++ b/test/codegen/test_gen.ml
@@ -12,24 +12,24 @@ let%expect_test "simple string match" =
 
       state0 [label="0"];
       state0 -> state1 [label="'a'"];
-      state0 -> state3 [label="'d'"];
+      state0 -> state2 [label="'d'"];
       state1 [label="1"];
-      state1 -> state2 [label="'b'"];
-      state2 [label="2\n[rule 0]", shape=doublecircle];
-      state3 [label="3"];
-      state3 -> state2 [label="'e'"];
+      state1 -> state3 [label="'b'"];
+      state2 [label="2"];
+      state2 -> state3 [label="'e'"];
+      state3 [label="3\n[rule 0]", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
-      | 1 -> __sedlex_state_3 buf
+      | 1 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
       | 0 -> 0
       | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_3 buf =
+    and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
       | 0 -> 0
       | _ -> Sedlexing.backtrack buf in
@@ -83,38 +83,38 @@ let%expect_test "multi-rule" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'0'-'9'"];
-      state0 -> state2 [label="'a'"];
-      state0 -> state4 [label="'d'"];
-      state1 [label="1\n[rule 2]", shape=doublecircle];
-      state1 -> state1 [label="'0'-'9'"];
+      state0 -> state3 [label="'0'-'9'"];
+      state0 -> state1 [label="'a'"];
+      state0 -> state2 [label="'d'"];
+      state1 [label="1"];
+      state1 -> state4 [label="'b'"];
       state2 [label="2"];
-      state2 -> state3 [label="'b'"];
-      state3 [label="3\n[rule 0]", shape=doublecircle];
-      state4 [label="4"];
-      state4 -> state5 [label="'e'"];
+      state2 -> state5 [label="'e'"];
+      state3 [label="3\n[rule 2]", shape=doublecircle];
+      state3 -> state3 [label="'0'-'9'"];
+      state4 [label="4\n[rule 0]", shape=doublecircle];
       state5 [label="5\n[rule 1]", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_1 buf
-      | 1 -> __sedlex_state_2 buf
-      | 2 -> __sedlex_state_4 buf
+      | 0 -> __sedlex_state_3 buf
+      | 1 -> __sedlex_state_1 buf
+      | 2 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
-      Sedlexing.mark buf 2;
-      (match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-       | 0 -> __sedlex_state_1 buf
-       | _ -> Sedlexing.backtrack buf)
-    and __sedlex_state_2 buf =
-      match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
+      match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
       | 0 -> 0
       | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_4 buf =
-      match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
+    and __sedlex_state_2 buf =
+      match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
       | 0 -> 1
-      | _ -> Sedlexing.backtrack buf in
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_3 buf =
+      Sedlexing.mark buf 2;
+      (match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
+       | 0 -> __sedlex_state_3 buf
+       | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf; __sedlex_state_0 buf with
     | 0 -> ()
     | 1 -> ()
@@ -324,10 +324,10 @@ let%expect_test "as binding: shared prefix or-pattern" =
       state4 [label="4"];
       state4 -> state5 [label="'e'"];
       state5 [label="5"];
-      state5 -> state6 [label="'f' {d0=0}"];
-      state5 -> state7 [label="'y' {d0=1}"];
-      state6 [label="6\n[rule 0]", shape=doublecircle];
-      state7 [label="7\n[rule 0]", shape=doublecircle];
+      state5 -> state6 [label="'f' {d1=0}"];
+      state5 -> state7 [label="'y' {d1=1}"];
+      state6 [label="6\n[rule 0]\n{t0<-t1}", shape=doublecircle];
+      state7 [label="7\n[rule 0]\n{t0<-t1}", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
@@ -352,11 +352,17 @@ let%expect_test "as binding: shared prefix or-pattern" =
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_5 buf =
       match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_value buf 0 0; 0)
-      | 1 -> (Sedlexing.__private__set_mem_value buf 0 1; 0)
+      | 0 ->
+          (Sedlexing.__private__set_mem_value buf 1 0;
+           Sedlexing.__private__copy_mem buf 0 1;
+           0)
+      | 1 ->
+          (Sedlexing.__private__set_mem_value buf 1 1;
+           Sedlexing.__private__copy_mem buf 0 1;
+           0)
       | _ -> Sedlexing.backtrack buf in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 1;
+          Sedlexing.__private__init_mem buf 2;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -395,12 +401,12 @@ let%expect_test "as binding: 3-way or reuses disc cell" =
       state2 [label="2"];
       state2 -> state3 [label="'c'"];
       state3 [label="3"];
-      state3 -> state4 [label="'d' {d0=0}"];
-      state3 -> state6 [label="'e' {d0=1}"];
-      state4 [label="4\n[rule 0]", shape=doublecircle];
-      state4 -> state5 [label="'f' {d0=0}"];
-      state5 [label="5\n[rule 0]", shape=doublecircle];
-      state6 [label="6\n[rule 0]", shape=doublecircle];
+      state3 -> state4 [label="'d' {d1=0}"];
+      state3 -> state5 [label="'e' {d1=1}"];
+      state4 [label="4\n[rule 0]\n{t0<-t1}", shape=doublecircle];
+      state4 -> state6 [label="'f' {d1=0}"];
+      state5 [label="5\n[rule 0]\n{t0<-t1}", shape=doublecircle];
+      state6 [label="6\n[rule 0]\n{t0<-t1}", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
@@ -417,16 +423,23 @@ let%expect_test "as binding: 3-way or reuses disc cell" =
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_3 buf =
       match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_value buf 0 0; __sedlex_state_4 buf)
-      | 1 -> (Sedlexing.__private__set_mem_value buf 0 1; 0)
+      | 0 -> (Sedlexing.__private__set_mem_value buf 1 0; __sedlex_state_4 buf)
+      | 1 ->
+          (Sedlexing.__private__set_mem_value buf 1 1;
+           Sedlexing.__private__copy_mem buf 0 1;
+           0)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_4 buf =
+      Sedlexing.__private__copy_mem buf 0 1;
       Sedlexing.mark buf 0;
       (match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
-       | 0 -> (Sedlexing.__private__set_mem_value buf 0 0; 0)
+       | 0 ->
+           (Sedlexing.__private__set_mem_value buf 1 0;
+            Sedlexing.__private__copy_mem buf 0 1;
+            0)
        | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 1;
+          Sedlexing.__private__init_mem buf 2;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -467,25 +480,25 @@ let%expect_test "as binding: multi-rule" =
 
       state0 [label="0"];
       state0 -> state1 [label="'a'"];
-      state0 -> state3 [label="'c'"];
+      state0 -> state2 [label="'c'"];
       state1 [label="1"];
-      state1 -> state2 [label="'b'"];
-      state2 [label="2\n[rule 0]", shape=doublecircle];
-      state3 [label="3"];
-      state3 -> state4 [label="'d'"];
+      state1 -> state3 [label="'b'"];
+      state2 [label="2"];
+      state2 -> state4 [label="'d'"];
+      state3 [label="3\n[rule 0]", shape=doublecircle];
       state4 [label="4\n[rule 1]", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
-      | 1 -> __sedlex_state_3 buf
+      | 1 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
       | 0 -> 0
       | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_3 buf =
+    and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
       | 0 -> 1
       | _ -> Sedlexing.backtrack buf in
@@ -545,8 +558,10 @@ let%expect_test "as binding: wrapping alternation" =
 (* Optimization 1: Element-length (Offset_from_tag)
    When neither prefix nor suffix length is known but the element itself
    has a fixed codepoint length, only 1 tag should be needed instead of 2.
-   Current: init_mem 1 (1 tag, end = tag + 1).
-   Goal: init_mem 1 — already optimal. *)
+   Current: init_mem 2 (1 logical tag: canonical cell + working register;
+   end = tag + 1).
+   Goal: init_mem 1 (write conflict-free tags directly to their canonical
+   cell instead of materializing at accepting states). *)
 let%expect_test "optim: element-length (Offset_from_tag)" =
   (match%sedlex_test buf with
     | Plus 'a', ('b' as x), Plus 'c' -> ignore x
@@ -562,23 +577,23 @@ let%expect_test "optim: element-length (Offset_from_tag)" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'a' {t0}"];
+      state0 -> state1 [label="'a' {t1}"];
       state1 [label="1"];
-      state1 -> state1 [label="'a' {t0}"];
+      state1 -> state1 [label="'a' {t1}"];
       state1 -> state2 [label="'b'"];
       state2 [label="2"];
       state2 -> state3 [label="'c'"];
-      state3 [label="3\n[rule 0]", shape=doublecircle];
+      state3 [label="3\n[rule 0]\n{t0<-t1}", shape=doublecircle];
       state3 -> state3 [label="'c'"];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
       | 1 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
@@ -586,12 +601,13 @@ let%expect_test "optim: element-length (Offset_from_tag)" =
       | 0 -> __sedlex_state_3 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_3 buf =
+      Sedlexing.__private__copy_mem buf 0 1;
       Sedlexing.mark buf 0;
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_3 buf
        | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 1;
+          Sedlexing.__private__init_mem buf 2;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -713,8 +729,9 @@ let%expect_test "optim: discriminator elision" =
 (* Optimization 4: Intra-rule tag coalescing
    Tags with identical occurrence signatures should share one memory cell.
    Here x_end and y_start fire on the same transitions.
-   Current: init_mem 1 (x_start=0, x_end=y_start via Tag offset, y_end=lexeme_length).
-   Goal: init_mem 1 — already optimal. *)
+   Current: init_mem 2 (1 logical tag — x_end=y_start via Tag offset,
+   y_end=lexeme_length — using a canonical cell plus a working register).
+   Goal: init_mem 1 (conflict-free tags written directly to canonical cell). *)
 let%expect_test "optim: intra-rule tag coalescing" =
   (match%sedlex_test buf with
     | (Plus 'a' as x), (Plus 'b' as y) -> ignore (x, y)
@@ -730,30 +747,31 @@ let%expect_test "optim: intra-rule tag coalescing" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'a' {t0}"];
+      state0 -> state1 [label="'a' {t1}"];
       state1 [label="1"];
-      state1 -> state1 [label="'a' {t0}"];
+      state1 -> state1 [label="'a' {t1}"];
       state1 -> state2 [label="'b'"];
-      state2 [label="2\n[rule 0]", shape=doublecircle];
+      state2 [label="2\n[rule 0]\n{t0<-t1}", shape=doublecircle];
       state2 -> state2 [label="'b'"];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
       | 1 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
+      Sedlexing.__private__copy_mem buf 0 1;
       Sedlexing.mark buf 0;
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_2 buf
        | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 1;
+          Sedlexing.__private__init_mem buf 2;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -773,8 +791,10 @@ let%expect_test "optim: intra-rule tag coalescing" =
    Non-interfering rules should reuse the same memory cells.
    Rule 0 and rule 1 never co-exist in the same DFA state (beyond state 0),
    so their tags can share cells.
-   Current: init_mem 4 (2 per rule: start + end tags for variable-length binding).
-   Goal: init_mem 2 (cells shared across non-interfering rules). *)
+   Current: init_mem 8 (2 logical tags per rule, each with a canonical cell
+   and a working register).
+   Goal: init_mem 2 (cells shared across non-interfering rules, conflict-free
+   tags written directly to canonical cells). *)
 let%expect_test "optim: cross-rule cell sharing" =
   (match%sedlex_test buf with
     | Plus 'a', (Plus 'b' as x), Plus 'c' -> ignore x
@@ -791,63 +811,67 @@ let%expect_test "optim: cross-rule cell sharing" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'a' {t0}"];
-      state0 -> state4 [label="'d' {t2}"];
+      state0 -> state1 [label="'a' {t4}"];
+      state0 -> state2 [label="'d' {t5}"];
       state1 [label="1"];
-      state1 -> state1 [label="'a' {t0}"];
-      state1 -> state2 [label="'b' {t1}"];
+      state1 -> state1 [label="'a' {t4}"];
+      state1 -> state3 [label="'b' {t6}"];
       state2 [label="2"];
-      state2 -> state2 [label="'b' {t1}"];
-      state2 -> state3 [label="'c'"];
-      state3 [label="3\n[rule 0]", shape=doublecircle];
-      state3 -> state3 [label="'c'"];
+      state2 -> state2 [label="'d' {t5}"];
+      state2 -> state4 [label="'e' {t7}"];
+      state3 [label="3"];
+      state3 -> state3 [label="'b' {t6}"];
+      state3 -> state5 [label="'c'"];
       state4 [label="4"];
-      state4 -> state4 [label="'d' {t2}"];
-      state4 -> state5 [label="'e' {t3}"];
-      state5 [label="5"];
-      state5 -> state5 [label="'e' {t3}"];
-      state5 -> state6 [label="'f'"];
-      state6 [label="6\n[rule 1]", shape=doublecircle];
+      state4 -> state4 [label="'e' {t7}"];
+      state4 -> state6 [label="'f'"];
+      state5 [label="5\n[rule 0]\n{t1<-t6,t0<-t4}", shape=doublecircle];
+      state5 -> state5 [label="'c'"];
+      state6 [label="6\n[rule 1]\n{t3<-t7,t2<-t5}", shape=doublecircle];
       state6 -> state6 [label="'f'"];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
-      | 1 -> (Sedlexing.__private__set_mem_pos buf 2; __sedlex_state_4 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 4; __sedlex_state_1 buf)
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 5; __sedlex_state_2 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
-      | 1 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_2 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 4; __sedlex_state_1 buf)
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 6; __sedlex_state_3 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_2 buf)
-      | 1 -> __sedlex_state_3 buf
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 5; __sedlex_state_2 buf)
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 7; __sedlex_state_4 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_3 buf =
-      Sedlexing.mark buf 0;
-      (match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
-       | 0 -> __sedlex_state_3 buf
-       | _ -> Sedlexing.backtrack buf)
+      match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 6; __sedlex_state_3 buf)
+      | 1 -> __sedlex_state_5 buf
+      | _ -> Sedlexing.backtrack buf
     and __sedlex_state_4 buf =
       match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 2; __sedlex_state_4 buf)
-      | 1 -> (Sedlexing.__private__set_mem_pos buf 3; __sedlex_state_5 buf)
-      | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_5 buf =
-      match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 3; __sedlex_state_5 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 7; __sedlex_state_4 buf)
       | 1 -> __sedlex_state_6 buf
       | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_5 buf =
+      Sedlexing.__private__copy_mem buf 1 6;
+      Sedlexing.__private__copy_mem buf 0 4;
+      Sedlexing.mark buf 0;
+      (match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
+       | 0 -> __sedlex_state_5 buf
+       | _ -> Sedlexing.backtrack buf)
     and __sedlex_state_6 buf =
+      Sedlexing.__private__copy_mem buf 3 7;
+      Sedlexing.__private__copy_mem buf 2 5;
       Sedlexing.mark buf 1;
       (match __sedlex_partition_7 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_6 buf
        | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 4;
+          Sedlexing.__private__init_mem buf 8;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -870,8 +894,8 @@ let%expect_test "optim: cross-rule cell sharing" =
    a final state should be removed.
    Rule 0 has a binding on Plus 'b'; rule 1 does not.
    Both share the Plus 'a', Plus 'b' prefix in the DFA.
-   Current: init_mem 1, tag t0 set on shared prefix transitions
-   even when only rule 1 is reachable via 'd'.
+   Current: init_mem 2, the tag's working register set on shared prefix
+   transitions even when only rule 1 is reachable via 'd'.
    Goal: no tags on transitions leading exclusively to rule 1. *)
 let%expect_test "optim: dead tag elimination" =
   (match%sedlex_test buf with
@@ -889,35 +913,35 @@ let%expect_test "optim: dead tag elimination" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'a' {t0}"];
+      state0 -> state1 [label="'a' {t1}"];
       state1 [label="1"];
-      state1 -> state1 [label="'a' {t0}"];
+      state1 -> state1 [label="'a' {t1}"];
       state1 -> state2 [label="'b'"];
       state2 [label="2"];
       state2 -> state2 [label="'b'"];
       state2 -> state3 [label="'c'"];
       state2 -> state4 [label="'d'"];
-      state3 [label="3\n[rule 0]", shape=doublecircle];
+      state3 [label="3\n[rule 0]\n{t0<-t1}", shape=doublecircle];
       state4 [label="4\n[rule 1]", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
       | 1 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_2 buf
-      | 1 -> 0
+      | 1 -> (Sedlexing.__private__copy_mem buf 0 1; 0)
       | 2 -> 1
       | _ -> Sedlexing.backtrack buf in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 1;
+          Sedlexing.__private__init_mem buf 2;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -933,7 +957,7 @@ let%expect_test "optim: dead tag elimination" =
 (* Optimization 7: Self-loop tag delay (Set_prev)
    Tags on a self-loop that also appear on all entering transitions
    should be delayed to exit transitions as Set_prev.
-   Current: init_mem 1, set_mem t0 on every 'a' iteration (O(n)).
+   Current: init_mem 2, set_mem on every 'a' iteration (O(n)).
    Goal: no set_mem on the self-loop, set_mem_prev on exit (O(1)). *)
 let%expect_test "optim: self-loop tag delay" =
   (match%sedlex_test buf with (Plus 'a' as x), Plus 'b' -> ignore x | _ -> ());
@@ -948,30 +972,31 @@ let%expect_test "optim: self-loop tag delay" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'a' {t0}"];
+      state0 -> state1 [label="'a' {t1}"];
       state1 [label="1"];
-      state1 -> state1 [label="'a' {t0}"];
+      state1 -> state1 [label="'a' {t1}"];
       state1 -> state2 [label="'b'"];
-      state2 [label="2\n[rule 0]", shape=doublecircle];
+      state2 [label="2\n[rule 0]\n{t0<-t1}", shape=doublecircle];
       state2 -> state2 [label="'b'"];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
       | 1 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
+      Sedlexing.__private__copy_mem buf 0 1;
       Sedlexing.mark buf 0;
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_2 buf
        | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 1;
+          Sedlexing.__private__init_mem buf 2;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -1046,7 +1071,7 @@ let%expect_test "optim: tag remapping after coalescing" =
    Opt at the end means the DFA can accept at two states (with or without
    the optional 'a'). When self-loop tag delay is implemented, the delayed
    tags (Set_prev) must survive mark/backtrack correctly.
-   Current: init_mem 1 (x: start=0, end=tag0; y: start=tag0, end=lexeme_length). *)
+   Current: init_mem 2 (1 logical tag: x ends and y starts at it). *)
 let%expect_test "optim: set_prev with backtracking" =
   (match%sedlex_test buf with
     | (Plus 'a' as x), ((Plus 'b', Opt 'a') as y) -> ignore (x, y)
@@ -1062,33 +1087,34 @@ let%expect_test "optim: set_prev with backtracking" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'a' {t0}"];
+      state0 -> state1 [label="'a' {t1}"];
       state1 [label="1"];
-      state1 -> state1 [label="'a' {t0}"];
+      state1 -> state1 [label="'a' {t1}"];
       state1 -> state2 [label="'b'"];
-      state2 [label="2\n[rule 0]", shape=doublecircle];
+      state2 [label="2\n[rule 0]\n{t0<-t1}", shape=doublecircle];
       state2 -> state3 [label="'a'"];
       state2 -> state2 [label="'b'"];
-      state3 [label="3\n[rule 0]", shape=doublecircle];
+      state3 [label="3\n[rule 0]\n{t0<-t1}", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
       | 1 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
+      Sedlexing.__private__copy_mem buf 0 1;
       Sedlexing.mark buf 0;
       (match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-       | 0 -> 0
+       | 0 -> (Sedlexing.__private__copy_mem buf 0 1; 0)
        | 1 -> __sedlex_state_2 buf
        | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 1;
+          Sedlexing.__private__init_mem buf 2;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -1183,80 +1209,88 @@ let%expect_test "as binding: or-chain then nested or on right" =
 
       state0 [label="0"];
       state0 -> state1 [label="'a'"];
-      state0 -> state5 [label="'c'"];
+      state0 -> state2 [label="'c'"];
       state1 [label="1"];
-      state1 -> state2 [label="'b'"];
+      state1 -> state3 [label="'b'"];
       state2 [label="2"];
-      state2 -> state3 [label="'e'"];
+      state2 -> state4 [label="'d'"];
+      state2 -> state5 [label="'e'"];
       state3 [label="3"];
-      state3 -> state4 [label="'f' {d1=0}"];
-      state4 [label="4\n[rule 0]", shape=doublecircle];
+      state3 -> state6 [label="'e'"];
+      state4 [label="4"];
+      state4 -> state7 [label="'e'"];
       state5 [label="5"];
-      state5 -> state6 [label="'d'"];
-      state5 -> state11 [label="'e'"];
+      state5 -> state8 [label="'f' {d2=1}"];
       state6 [label="6"];
-      state6 -> state7 [label="'e'"];
+      state6 -> state9 [label="'f' {d4=1,d3=0}"];
       state7 [label="7"];
-      state7 -> state8 [label="'f' {d0=0}"];
+      state7 -> state10 [label="'f' {d2=0}"];
       state8 [label="8"];
-      state8 -> state9 [label="'g'"];
-      state9 [label="9"];
-      state9 -> state10 [label="'h' {d1=2}"];
-      state10 [label="10\n[rule 0]", shape=doublecircle];
+      state8 -> state11 [label="'g'"];
+      state9 [label="9\n[rule 0]\n{t1<-t3}", shape=doublecircle];
+      state10 [label="10"];
+      state10 -> state11 [label="'g'"];
       state11 [label="11"];
-      state11 -> state12 [label="'f' {d0=1}"];
-      state12 [label="12"];
-      state12 -> state9 [label="'g'"];
+      state11 -> state12 [label="'h' {d4=2}"];
+      state12 [label="12\n[rule 0]\n{t1<-t4,t0<-t2}", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_1 buf
-      | 1 -> __sedlex_state_5 buf
+      | 1 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_2 buf
+      | 0 -> __sedlex_state_3 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_3 buf
+      | 0 -> __sedlex_state_4 buf
+      | 1 -> __sedlex_state_5 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_3 buf =
       match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_value buf 1 0; 0)
+      | 0 -> __sedlex_state_6 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_4 buf =
+      match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_7 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_5 buf =
       match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_6 buf
-      | 1 -> __sedlex_state_11 buf
+      | 0 -> (Sedlexing.__private__set_mem_value buf 2 1; __sedlex_state_8 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_6 buf =
-      match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_7 buf
+      match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
+      | 0 ->
+          (Sedlexing.__private__set_mem_value buf 4 1;
+           Sedlexing.__private__set_mem_value buf 3 0;
+           Sedlexing.__private__copy_mem buf 1 3;
+           0)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_7 buf =
-      match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_value buf 0 0; __sedlex_state_8 buf)
+      match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_value buf 2 0; __sedlex_state_10 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_8 buf =
       match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_9 buf
+      | 0 -> __sedlex_state_11 buf
       | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_9 buf =
-      match __sedlex_partition_7 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_value buf 1 2; 0)
+    and __sedlex_state_10 buf =
+      match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_11 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_11 buf =
-      match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_value buf 0 1; __sedlex_state_12 buf)
-      | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_12 buf =
-      match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_9 buf
+      match __sedlex_partition_7 (Sedlexing.__private__next_int buf) with
+      | 0 ->
+          (Sedlexing.__private__set_mem_value buf 4 2;
+           Sedlexing.__private__copy_mem buf 1 4;
+           Sedlexing.__private__copy_mem buf 0 2;
+           0)
       | _ -> Sedlexing.backtrack buf in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 2;
+          Sedlexing.__private__init_mem buf 5;
           __sedlex_state_0 buf
     with
     | 0 ->

--- a/test/codegen/test_gen.ml
+++ b/test/codegen/test_gen.ml
@@ -324,10 +324,9 @@ let%expect_test "as binding: shared prefix or-pattern" =
       state4 [label="4"];
       state4 -> state5 [label="'e'"];
       state5 [label="5"];
-      state5 -> state6 [label="'f' {d1=0}"];
-      state5 -> state7 [label="'y' {d1=1}"];
-      state6 [label="6\n[rule 0]\n{t0<-t1}", shape=doublecircle];
-      state7 [label="7\n[rule 0]\n{t0<-t1}", shape=doublecircle];
+      state5 -> state6 [label="'f' {d0=0}"];
+      state5 -> state6 [label="'y' {d0=1}"];
+      state6 [label="6\n[rule 0]", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
@@ -352,17 +351,11 @@ let%expect_test "as binding: shared prefix or-pattern" =
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_5 buf =
       match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
-      | 0 ->
-          (Sedlexing.__private__set_mem_value buf 1 0;
-           Sedlexing.__private__copy_mem buf 0 1;
-           0)
-      | 1 ->
-          (Sedlexing.__private__set_mem_value buf 1 1;
-           Sedlexing.__private__copy_mem buf 0 1;
-           0)
+      | 0 -> (Sedlexing.__private__set_mem_value buf 0 0; 0)
+      | 1 -> (Sedlexing.__private__set_mem_value buf 0 1; 0)
       | _ -> Sedlexing.backtrack buf in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 2;
+          Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -401,12 +394,11 @@ let%expect_test "as binding: 3-way or reuses disc cell" =
       state2 [label="2"];
       state2 -> state3 [label="'c'"];
       state3 [label="3"];
-      state3 -> state4 [label="'d' {d1=0}"];
-      state3 -> state5 [label="'e' {d1=1}"];
-      state4 [label="4\n[rule 0]\n{t0<-t1}", shape=doublecircle];
-      state4 -> state6 [label="'f' {d1=0}"];
-      state5 [label="5\n[rule 0]\n{t0<-t1}", shape=doublecircle];
-      state6 [label="6\n[rule 0]\n{t0<-t1}", shape=doublecircle];
+      state3 -> state4 [label="'d' {d0=0}"];
+      state3 -> state5 [label="'e' {d0=1}"];
+      state4 [label="4\n[rule 0]", shape=doublecircle];
+      state4 -> state5 [label="'f' {d0=0}"];
+      state5 [label="5\n[rule 0]", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
@@ -423,23 +415,16 @@ let%expect_test "as binding: 3-way or reuses disc cell" =
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_3 buf =
       match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_value buf 1 0; __sedlex_state_4 buf)
-      | 1 ->
-          (Sedlexing.__private__set_mem_value buf 1 1;
-           Sedlexing.__private__copy_mem buf 0 1;
-           0)
+      | 0 -> (Sedlexing.__private__set_mem_value buf 0 0; __sedlex_state_4 buf)
+      | 1 -> (Sedlexing.__private__set_mem_value buf 0 1; 0)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_4 buf =
-      Sedlexing.__private__copy_mem buf 0 1;
       Sedlexing.mark buf 0;
       (match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
-       | 0 ->
-           (Sedlexing.__private__set_mem_value buf 1 0;
-            Sedlexing.__private__copy_mem buf 0 1;
-            0)
+       | 0 -> (Sedlexing.__private__set_mem_value buf 0 0; 0)
        | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 2;
+          Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -558,10 +543,8 @@ let%expect_test "as binding: wrapping alternation" =
 (* Optimization 1: Element-length (Offset_from_tag)
    When neither prefix nor suffix length is known but the element itself
    has a fixed codepoint length, only 1 tag should be needed instead of 2.
-   Current: init_mem 2 (1 logical tag: canonical cell + working register;
-   end = tag + 1).
-   Goal: init_mem 1 (write conflict-free tags directly to their canonical
-   cell instead of materializing at accepting states). *)
+   Current: init_mem 1 (1 conflict-free tag in its canonical cell;
+   end = tag + 1) — already optimal. *)
 let%expect_test "optim: element-length (Offset_from_tag)" =
   (match%sedlex_test buf with
     | Plus 'a', ('b' as x), Plus 'c' -> ignore x
@@ -577,23 +560,23 @@ let%expect_test "optim: element-length (Offset_from_tag)" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'a' {t1}"];
+      state0 -> state1 [label="'a' {t0}"];
       state1 [label="1"];
-      state1 -> state1 [label="'a' {t1}"];
+      state1 -> state1 [label="'a' {t0}"];
       state1 -> state2 [label="'b'"];
       state2 [label="2"];
       state2 -> state3 [label="'c'"];
-      state3 [label="3\n[rule 0]\n{t0<-t1}", shape=doublecircle];
+      state3 [label="3\n[rule 0]", shape=doublecircle];
       state3 -> state3 [label="'c'"];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
       | 1 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
@@ -601,13 +584,12 @@ let%expect_test "optim: element-length (Offset_from_tag)" =
       | 0 -> __sedlex_state_3 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_3 buf =
-      Sedlexing.__private__copy_mem buf 0 1;
       Sedlexing.mark buf 0;
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_3 buf
        | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 2;
+          Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -729,9 +711,8 @@ let%expect_test "optim: discriminator elision" =
 (* Optimization 4: Intra-rule tag coalescing
    Tags with identical occurrence signatures should share one memory cell.
    Here x_end and y_start fire on the same transitions.
-   Current: init_mem 2 (1 logical tag — x_end=y_start via Tag offset,
-   y_end=lexeme_length — using a canonical cell plus a working register).
-   Goal: init_mem 1 (conflict-free tags written directly to canonical cell). *)
+   Current: init_mem 1 (1 conflict-free tag — x_end=y_start via Tag offset,
+   y_end=lexeme_length) — already optimal. *)
 let%expect_test "optim: intra-rule tag coalescing" =
   (match%sedlex_test buf with
     | (Plus 'a' as x), (Plus 'b' as y) -> ignore (x, y)
@@ -747,31 +728,30 @@ let%expect_test "optim: intra-rule tag coalescing" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'a' {t1}"];
+      state0 -> state1 [label="'a' {t0}"];
       state1 [label="1"];
-      state1 -> state1 [label="'a' {t1}"];
+      state1 -> state1 [label="'a' {t0}"];
       state1 -> state2 [label="'b'"];
-      state2 [label="2\n[rule 0]\n{t0<-t1}", shape=doublecircle];
+      state2 [label="2\n[rule 0]", shape=doublecircle];
       state2 -> state2 [label="'b'"];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
       | 1 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
-      Sedlexing.__private__copy_mem buf 0 1;
       Sedlexing.mark buf 0;
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_2 buf
        | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 2;
+          Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -791,10 +771,9 @@ let%expect_test "optim: intra-rule tag coalescing" =
    Non-interfering rules should reuse the same memory cells.
    Rule 0 and rule 1 never co-exist in the same DFA state (beyond state 0),
    so their tags can share cells.
-   Current: init_mem 8 (2 logical tags per rule, each with a canonical cell
-   and a working register).
-   Goal: init_mem 2 (cells shared across non-interfering rules, conflict-free
-   tags written directly to canonical cells). *)
+   Current: init_mem 4 (2 conflict-free tags per rule, each in its
+   canonical cell).
+   Goal: init_mem 2 (cells shared across non-interfering rules). *)
 let%expect_test "optim: cross-rule cell sharing" =
   (match%sedlex_test buf with
     | Plus 'a', (Plus 'b' as x), Plus 'c' -> ignore x
@@ -811,67 +790,63 @@ let%expect_test "optim: cross-rule cell sharing" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'a' {t4}"];
-      state0 -> state2 [label="'d' {t5}"];
+      state0 -> state1 [label="'a' {t0}"];
+      state0 -> state2 [label="'d' {t2}"];
       state1 [label="1"];
-      state1 -> state1 [label="'a' {t4}"];
-      state1 -> state3 [label="'b' {t6}"];
+      state1 -> state1 [label="'a' {t0}"];
+      state1 -> state3 [label="'b' {t1}"];
       state2 [label="2"];
-      state2 -> state2 [label="'d' {t5}"];
-      state2 -> state4 [label="'e' {t7}"];
+      state2 -> state2 [label="'d' {t2}"];
+      state2 -> state4 [label="'e' {t3}"];
       state3 [label="3"];
-      state3 -> state3 [label="'b' {t6}"];
+      state3 -> state3 [label="'b' {t1}"];
       state3 -> state5 [label="'c'"];
       state4 [label="4"];
-      state4 -> state4 [label="'e' {t7}"];
+      state4 -> state4 [label="'e' {t3}"];
       state4 -> state6 [label="'f'"];
-      state5 [label="5\n[rule 0]\n{t1<-t6,t0<-t4}", shape=doublecircle];
+      state5 [label="5\n[rule 0]", shape=doublecircle];
       state5 -> state5 [label="'c'"];
-      state6 [label="6\n[rule 1]\n{t3<-t7,t2<-t5}", shape=doublecircle];
+      state6 [label="6\n[rule 1]", shape=doublecircle];
       state6 -> state6 [label="'f'"];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 4; __sedlex_state_1 buf)
-      | 1 -> (Sedlexing.__private__set_mem_pos buf 5; __sedlex_state_2 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 2; __sedlex_state_2 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 4; __sedlex_state_1 buf)
-      | 1 -> (Sedlexing.__private__set_mem_pos buf 6; __sedlex_state_3 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_3 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 5; __sedlex_state_2 buf)
-      | 1 -> (Sedlexing.__private__set_mem_pos buf 7; __sedlex_state_4 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 2; __sedlex_state_2 buf)
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 3; __sedlex_state_4 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_3 buf =
       match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 6; __sedlex_state_3 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_3 buf)
       | 1 -> __sedlex_state_5 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_4 buf =
       match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 7; __sedlex_state_4 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 3; __sedlex_state_4 buf)
       | 1 -> __sedlex_state_6 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_5 buf =
-      Sedlexing.__private__copy_mem buf 1 6;
-      Sedlexing.__private__copy_mem buf 0 4;
       Sedlexing.mark buf 0;
       (match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_5 buf
        | _ -> Sedlexing.backtrack buf)
     and __sedlex_state_6 buf =
-      Sedlexing.__private__copy_mem buf 3 7;
-      Sedlexing.__private__copy_mem buf 2 5;
       Sedlexing.mark buf 1;
       (match __sedlex_partition_7 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_6 buf
        | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 8;
+          Sedlexing.__private__init_mem buf 4;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -894,8 +869,8 @@ let%expect_test "optim: cross-rule cell sharing" =
    a final state should be removed.
    Rule 0 has a binding on Plus 'b'; rule 1 does not.
    Both share the Plus 'a', Plus 'b' prefix in the DFA.
-   Current: init_mem 2, the tag's working register set on shared prefix
-   transitions even when only rule 1 is reachable via 'd'.
+   Current: init_mem 1, the tag set on shared prefix transitions
+   even when only rule 1 is reachable via 'd'.
    Goal: no tags on transitions leading exclusively to rule 1. *)
 let%expect_test "optim: dead tag elimination" =
   (match%sedlex_test buf with
@@ -913,35 +888,35 @@ let%expect_test "optim: dead tag elimination" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'a' {t1}"];
+      state0 -> state1 [label="'a' {t0}"];
       state1 [label="1"];
-      state1 -> state1 [label="'a' {t1}"];
+      state1 -> state1 [label="'a' {t0}"];
       state1 -> state2 [label="'b'"];
       state2 [label="2"];
       state2 -> state2 [label="'b'"];
       state2 -> state3 [label="'c'"];
       state2 -> state4 [label="'d'"];
-      state3 [label="3\n[rule 0]\n{t0<-t1}", shape=doublecircle];
+      state3 [label="3\n[rule 0]", shape=doublecircle];
       state4 [label="4\n[rule 1]", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
       | 1 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_2 buf
-      | 1 -> (Sedlexing.__private__copy_mem buf 0 1; 0)
+      | 1 -> 0
       | 2 -> 1
       | _ -> Sedlexing.backtrack buf in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 2;
+          Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -954,10 +929,72 @@ let%expect_test "optim: dead tag elimination" =
     | _ -> ()
     |}]
 
+(* Conflicted tag: a Star loop whose epsilon closure contains the start
+   node of the following capture. The loop path re-fires the start tag on
+   every 'a' while the path already inside the capture must keep its
+   earlier position, so the tag needs two working registers besides its
+   canonical cell: the transition saves the clobbered source in a
+   let-bound local (parallel move) and accepting states materialize the
+   accepting path's register into the canonical cell ({t0<-tN}). *)
+let%expect_test "conflicted tag: star before overlapping capture" =
+  (match%sedlex_test buf with
+    | Star 'a', (('a', Plus 'b') as x) -> ignore x
+    | _ -> ());
+  [%expect {|
+    DOT:
+    digraph {
+      rankdir=LR;
+      node [shape=circle];
+
+      _start [shape=point];
+      _start -> state0;
+
+      state0 [label="0"];
+      state0 -> state1 [label="'a' {t2}"];
+      state1 [label="1"];
+      state1 -> state1 [label="'a' {t1<-t2,t2}"];
+      state1 -> state2 [label="'b'"];
+      state2 [label="2\n[rule 0]\n{t0<-t1}", shape=doublecircle];
+      state2 -> state2 [label="'b'"];
+    }
+    CODE:
+    let rec __sedlex_state_0 buf =
+      match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 2; __sedlex_state_1 buf)
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_1 buf =
+      match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
+      | 0 ->
+          let __sedlex_mem_2 = Sedlexing.__private__mem_get buf 2 in
+          (Sedlexing.__private__mem_set buf 1 __sedlex_mem_2;
+           Sedlexing.__private__set_mem_pos buf 2;
+           __sedlex_state_1 buf)
+      | 1 -> __sedlex_state_2 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_2 buf =
+      Sedlexing.__private__copy_mem buf 0 1;
+      Sedlexing.mark buf 0;
+      (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
+       | 0 -> __sedlex_state_2 buf
+       | _ -> Sedlexing.backtrack buf) in
+    match Sedlexing.start buf;
+          Sedlexing.__private__init_mem buf 3;
+          Sedlexing.__private__set_mem_pos buf 1;
+          __sedlex_state_0 buf
+    with
+    | 0 ->
+        let x =
+          let __s = Sedlexing.__private__mem_pos buf 0 in
+          let __e = Sedlexing.lexeme_length buf in
+          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
+        ignore x
+    | _ -> ()
+    |}]
+
 (* Optimization 7: Self-loop tag delay (Set_prev)
    Tags on a self-loop that also appear on all entering transitions
    should be delayed to exit transitions as Set_prev.
-   Current: init_mem 2, set_mem on every 'a' iteration (O(n)).
+   Current: init_mem 1, set_mem on every 'a' iteration (O(n)).
    Goal: no set_mem on the self-loop, set_mem_prev on exit (O(1)). *)
 let%expect_test "optim: self-loop tag delay" =
   (match%sedlex_test buf with (Plus 'a' as x), Plus 'b' -> ignore x | _ -> ());
@@ -972,31 +1009,30 @@ let%expect_test "optim: self-loop tag delay" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'a' {t1}"];
+      state0 -> state1 [label="'a' {t0}"];
       state1 [label="1"];
-      state1 -> state1 [label="'a' {t1}"];
+      state1 -> state1 [label="'a' {t0}"];
       state1 -> state2 [label="'b'"];
-      state2 [label="2\n[rule 0]\n{t0<-t1}", shape=doublecircle];
+      state2 [label="2\n[rule 0]", shape=doublecircle];
       state2 -> state2 [label="'b'"];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
       | 1 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
-      Sedlexing.__private__copy_mem buf 0 1;
       Sedlexing.mark buf 0;
       (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_2 buf
        | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 2;
+          Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -1071,7 +1107,7 @@ let%expect_test "optim: tag remapping after coalescing" =
    Opt at the end means the DFA can accept at two states (with or without
    the optional 'a'). When self-loop tag delay is implemented, the delayed
    tags (Set_prev) must survive mark/backtrack correctly.
-   Current: init_mem 2 (1 logical tag: x ends and y starts at it). *)
+   Current: init_mem 1 (1 conflict-free tag: x ends and y starts at it). *)
 let%expect_test "optim: set_prev with backtracking" =
   (match%sedlex_test buf with
     | (Plus 'a' as x), ((Plus 'b', Opt 'a') as y) -> ignore (x, y)
@@ -1087,34 +1123,33 @@ let%expect_test "optim: set_prev with backtracking" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'a' {t1}"];
+      state0 -> state1 [label="'a' {t0}"];
       state1 [label="1"];
-      state1 -> state1 [label="'a' {t1}"];
+      state1 -> state1 [label="'a' {t0}"];
       state1 -> state2 [label="'b'"];
-      state2 [label="2\n[rule 0]\n{t0<-t1}", shape=doublecircle];
+      state2 [label="2\n[rule 0]", shape=doublecircle];
       state2 -> state3 [label="'a'"];
       state2 -> state2 [label="'b'"];
-      state3 [label="3\n[rule 0]\n{t0<-t1}", shape=doublecircle];
+      state3 [label="3\n[rule 0]", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_1 buf)
+      | 0 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
       | 1 -> __sedlex_state_2 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_2 buf =
-      Sedlexing.__private__copy_mem buf 0 1;
       Sedlexing.mark buf 0;
       (match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-       | 0 -> (Sedlexing.__private__copy_mem buf 0 1; 0)
+       | 0 -> 0
        | 1 -> __sedlex_state_2 buf
        | _ -> Sedlexing.backtrack buf) in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 2;
+          Sedlexing.__private__init_mem buf 1;
           __sedlex_state_0 buf
     with
     | 0 ->
@@ -1220,19 +1255,17 @@ let%expect_test "as binding: or-chain then nested or on right" =
       state4 [label="4"];
       state4 -> state7 [label="'e'"];
       state5 [label="5"];
-      state5 -> state8 [label="'f' {d2=1}"];
+      state5 -> state8 [label="'f' {d0=1}"];
       state6 [label="6"];
-      state6 -> state9 [label="'f' {d4=1,d3=0}"];
+      state6 -> state9 [label="'f' {d1=0}"];
       state7 [label="7"];
-      state7 -> state10 [label="'f' {d2=0}"];
+      state7 -> state8 [label="'f' {d0=0}"];
       state8 [label="8"];
-      state8 -> state11 [label="'g'"];
-      state9 [label="9\n[rule 0]\n{t1<-t3}", shape=doublecircle];
+      state8 -> state10 [label="'g'"];
+      state9 [label="9\n[rule 0]", shape=doublecircle];
       state10 [label="10"];
-      state10 -> state11 [label="'g'"];
-      state11 [label="11"];
-      state11 -> state12 [label="'h' {d4=2}"];
-      state12 [label="12\n[rule 0]\n{t1<-t4,t0<-t2}", shape=doublecircle];
+      state10 -> state11 [label="'h' {d1=2}"];
+      state11 [label="11\n[rule 0]", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
@@ -1259,38 +1292,26 @@ let%expect_test "as binding: or-chain then nested or on right" =
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_5 buf =
       match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_value buf 2 1; __sedlex_state_8 buf)
+      | 0 -> (Sedlexing.__private__set_mem_value buf 0 1; __sedlex_state_8 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_6 buf =
       match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
-      | 0 ->
-          (Sedlexing.__private__set_mem_value buf 4 1;
-           Sedlexing.__private__set_mem_value buf 3 0;
-           Sedlexing.__private__copy_mem buf 1 3;
-           0)
+      | 0 -> (Sedlexing.__private__set_mem_value buf 1 0; 0)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_7 buf =
       match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
-      | 0 -> (Sedlexing.__private__set_mem_value buf 2 0; __sedlex_state_10 buf)
+      | 0 -> (Sedlexing.__private__set_mem_value buf 0 0; __sedlex_state_8 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_8 buf =
       match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_11 buf
+      | 0 -> __sedlex_state_10 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_10 buf =
-      match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_11 buf
-      | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_11 buf =
       match __sedlex_partition_7 (Sedlexing.__private__next_int buf) with
-      | 0 ->
-          (Sedlexing.__private__set_mem_value buf 4 2;
-           Sedlexing.__private__copy_mem buf 1 4;
-           Sedlexing.__private__copy_mem buf 0 2;
-           0)
+      | 0 -> (Sedlexing.__private__set_mem_value buf 1 2; 0)
       | _ -> Sedlexing.backtrack buf in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 5;
+          Sedlexing.__private__init_mem buf 2;
           __sedlex_state_0 buf
     with
     | 0 ->

--- a/test/codegen/test_gen.ml
+++ b/test/codegen/test_gen.ml
@@ -373,58 +373,10 @@ let%expect_test "as binding: multiple bindings, no static elimination" =
     | _ -> ()
     |}]
 
-let%expect_test "as binding: or-pattern with discriminator" =
-  (match%sedlex_test buf with
-    | (Plus '0' .. '9' as x) | (Plus 'a' .. 'z' as x) -> ignore x
-    | _ -> ());
-  [%expect
-    {|
-    DOT:
-    digraph {
-      rankdir=LR;
-      node [shape=circle];
-
-      _start [shape=point];
-      _start -> state0;
-
-      state0 [label="0"];
-      state0 -> state1 [label="'0'-'9'"];
-      state0 -> state2 [label="'a'-'z'"];
-      state1 [label="1\n[rule 0]", shape=doublecircle];
-      state1 -> state1 [label="'0'-'9'"];
-      state2 [label="2\n[rule 0]", shape=doublecircle];
-      state2 -> state2 [label="'a'-'z'"];
-    }
-    CODE:
-    let rec __sedlex_state_0 buf =
-      match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_1 buf
-      | 1 -> __sedlex_state_2 buf
-      | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_1 buf =
-      Sedlexing.mark buf 0;
-      (match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-       | 0 -> __sedlex_state_1 buf
-       | _ -> Sedlexing.backtrack buf)
-    and __sedlex_state_2 buf =
-      Sedlexing.mark buf 0;
-      (match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
-       | 0 -> __sedlex_state_2 buf
-       | _ -> Sedlexing.backtrack buf) in
-    match Sedlexing.start buf; __sedlex_state_0 buf with
-    | 0 ->
-        let x =
-          let __s = 0 in
-          let __e = Sedlexing.lexeme_length buf in
-          { Sedlexing.lexbuf = buf; pos = __s; len = (__e - __s) } in
-        ignore x
-    | _ -> ()
-    |}]
-
-(* Counterpart of "as binding: or-pattern with discriminator" where the
-   positions cannot be derived statically: each branch allocates a real
-   position tag for x, and the branches get distinct discriminator values
-   so extraction can pick the right tag at runtime. *)
+(* Counterpart of "optim: discriminator elision" where the positions
+   cannot be derived statically: each branch allocates a real position
+   tag for x, and the branches get distinct discriminator values so
+   extraction can pick the right tag at runtime. *)
 let%expect_test "as binding: or-pattern with discriminator, no static \
                  elimination" =
   (match%sedlex_test buf with

--- a/test/codegen/test_realistic.ml
+++ b/test/codegen/test_realistic.ml
@@ -34,14 +34,14 @@ let%expect_test "realistic: multi-token lexer" =
       state0 -> state4 [label="'('"];
       state0 -> state3 [label="'0'"];
       state0 -> state5 [label="'1'-'9'"];
-      state0 -> state2 [label="'A'-'Z' {t3}"];
-      state0 -> state1 [label="'a'-'z' {t2}"];
+      state0 -> state2 [label="'A'-'Z' {t1}"];
+      state0 -> state1 [label="'a'-'z' {t0}"];
       state1 [label="1\n[rule 4]", shape=doublecircle];
       state1 -> state6 [label="'.'"];
-      state1 -> state1 [label="'a'-'z' {t2}"];
+      state1 -> state1 [label="'a'-'z' {t0}"];
       state2 [label="2"];
       state2 -> state7 [label="'='"];
-      state2 -> state2 [label="'A'-'Z' {t3}"];
+      state2 -> state2 [label="'A'-'Z' {t1}"];
       state3 [label="3\n[rule 4]", shape=doublecircle];
       state3 -> state5 [label="'0'-'9'"];
       state3 -> state8 [label="'x'"];
@@ -57,9 +57,9 @@ let%expect_test "realistic: multi-token lexer" =
       state8 -> state12 [label="'0'-'9', 'a'-'f'"];
       state9 [label="9"];
       state9 -> state13 [label="','"];
-      state10 [label="10\n[rule 0]\n{t0<-t2}", shape=doublecircle];
+      state10 [label="10\n[rule 0]", shape=doublecircle];
       state10 -> state10 [label="'a'-'z'"];
-      state11 [label="11\n[rule 1]\n{t1<-t3}", shape=doublecircle];
+      state11 [label="11\n[rule 1]", shape=doublecircle];
       state11 -> state11 [label="'0'-'9'"];
       state12 [label="12"];
       state12 -> state12 [label="'0'-'9', 'a'-'f'"];
@@ -77,19 +77,19 @@ let%expect_test "realistic: multi-token lexer" =
       | 0 -> __sedlex_state_4 buf
       | 1 -> __sedlex_state_3 buf
       | 2 -> __sedlex_state_5 buf
-      | 3 -> (Sedlexing.__private__set_mem_pos buf 3; __sedlex_state_2 buf)
-      | 4 -> (Sedlexing.__private__set_mem_pos buf 2; __sedlex_state_1 buf)
+      | 3 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_2 buf)
+      | 4 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
       Sedlexing.mark buf 4;
       (match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_6 buf
-       | 1 -> (Sedlexing.__private__set_mem_pos buf 2; __sedlex_state_1 buf)
+       | 1 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_1 buf)
        | _ -> Sedlexing.backtrack buf)
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_7 buf
-      | 1 -> (Sedlexing.__private__set_mem_pos buf 3; __sedlex_state_2 buf)
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_2 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_3 buf =
       Sedlexing.mark buf 4;
@@ -123,13 +123,11 @@ let%expect_test "realistic: multi-token lexer" =
       | 0 -> __sedlex_state_13 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_10 buf =
-      Sedlexing.__private__copy_mem buf 0 2;
       Sedlexing.mark buf 0;
       (match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_10 buf
        | _ -> Sedlexing.backtrack buf)
     and __sedlex_state_11 buf =
-      Sedlexing.__private__copy_mem buf 1 3;
       Sedlexing.mark buf 1;
       (match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
        | 0 -> __sedlex_state_11 buf
@@ -148,7 +146,7 @@ let%expect_test "realistic: multi-token lexer" =
       | 0 -> 3
       | _ -> Sedlexing.backtrack buf in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 4;
+          Sedlexing.__private__init_mem buf 2;
           __sedlex_state_0 buf
     with
     | 0 ->

--- a/test/codegen/test_realistic.ml
+++ b/test/codegen/test_realistic.ml
@@ -145,7 +145,7 @@ let%expect_test "realistic: multi-token lexer" =
       match __sedlex_partition_10 (Sedlexing.__private__next_int buf) with
       | 0 -> 3
       | _ -> Sedlexing.backtrack buf in
-    match Sedlexing.start buf;
+    match Sedlexing.__private__start buf;
           Sedlexing.__private__init_mem buf 2;
           __sedlex_state_0 buf
     with

--- a/test/codegen/test_realistic.ml
+++ b/test/codegen/test_realistic.ml
@@ -31,122 +31,124 @@ let%expect_test "realistic: multi-token lexer" =
       _start -> state0;
 
       state0 [label="0"];
-      state0 -> state1 [label="'('"];
-      state0 -> state6 [label="'0'"];
-      state0 -> state7 [label="'1'-'9'"];
-      state0 -> state11 [label="'A'-'Z' {t1}"];
-      state0 -> state14 [label="'a'-'z' {t0}"];
-      state1 [label="1"];
-      state1 -> state2 [label="'a'-'z'"];
+      state0 -> state4 [label="'('"];
+      state0 -> state3 [label="'0'"];
+      state0 -> state5 [label="'1'-'9'"];
+      state0 -> state2 [label="'A'-'Z' {t3}"];
+      state0 -> state1 [label="'a'-'z' {t2}"];
+      state1 [label="1\n[rule 4]", shape=doublecircle];
+      state1 -> state6 [label="'.'"];
+      state1 -> state1 [label="'a'-'z' {t2}"];
       state2 [label="2"];
-      state2 -> state3 [label="','"];
-      state3 [label="3"];
-      state3 -> state4 [label="'a'-'z'"];
+      state2 -> state7 [label="'='"];
+      state2 -> state2 [label="'A'-'Z' {t3}"];
+      state3 [label="3\n[rule 4]", shape=doublecircle];
+      state3 -> state5 [label="'0'-'9'"];
+      state3 -> state8 [label="'x'"];
       state4 [label="4"];
-      state4 -> state5 [label="')'"];
-      state5 [label="5\n[rule 3]", shape=doublecircle];
-      state6 [label="6\n[rule 4]", shape=doublecircle];
-      state6 -> state7 [label="'0'-'9'"];
-      state6 -> state8 [label="'x'"];
-      state7 [label="7\n[rule 4]", shape=doublecircle];
-      state7 -> state7 [label="'0'-'9'"];
+      state4 -> state9 [label="'a'-'z'"];
+      state5 [label="5\n[rule 4]", shape=doublecircle];
+      state5 -> state5 [label="'0'-'9'"];
+      state6 [label="6"];
+      state6 -> state10 [label="'a'-'z'"];
+      state7 [label="7"];
+      state7 -> state11 [label="'0'-'9'"];
       state8 [label="8"];
-      state8 -> state9 [label="'0'-'9', 'a'-'f'"];
+      state8 -> state12 [label="'0'-'9', 'a'-'f'"];
       state9 [label="9"];
-      state9 -> state9 [label="'0'-'9', 'a'-'f'"];
-      state9 -> state10 [label="';'"];
-      state10 [label="10\n[rule 2]", shape=doublecircle];
-      state11 [label="11"];
-      state11 -> state12 [label="'='"];
-      state11 -> state11 [label="'A'-'Z' {t1}"];
+      state9 -> state13 [label="','"];
+      state10 [label="10\n[rule 0]\n{t0<-t2}", shape=doublecircle];
+      state10 -> state10 [label="'a'-'z'"];
+      state11 [label="11\n[rule 1]\n{t1<-t3}", shape=doublecircle];
+      state11 -> state11 [label="'0'-'9'"];
       state12 [label="12"];
-      state12 -> state13 [label="'0'-'9'"];
-      state13 [label="13\n[rule 1]", shape=doublecircle];
-      state13 -> state13 [label="'0'-'9'"];
-      state14 [label="14\n[rule 4]", shape=doublecircle];
-      state14 -> state15 [label="'.'"];
-      state14 -> state14 [label="'a'-'z' {t0}"];
+      state12 -> state12 [label="'0'-'9', 'a'-'f'"];
+      state12 -> state14 [label="';'"];
+      state13 [label="13"];
+      state13 -> state15 [label="'a'-'z'"];
+      state14 [label="14\n[rule 2]", shape=doublecircle];
       state15 [label="15"];
-      state15 -> state16 [label="'a'-'z'"];
-      state16 [label="16\n[rule 0]", shape=doublecircle];
-      state16 -> state16 [label="'a'-'z'"];
+      state15 -> state16 [label="')'"];
+      state16 [label="16\n[rule 3]", shape=doublecircle];
     }
     CODE:
     let rec __sedlex_state_0 buf =
       match __sedlex_partition_1 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_1 buf
-      | 1 -> __sedlex_state_6 buf
-      | 2 -> __sedlex_state_7 buf
-      | 3 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_11 buf)
-      | 4 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_14 buf)
+      | 0 -> __sedlex_state_4 buf
+      | 1 -> __sedlex_state_3 buf
+      | 2 -> __sedlex_state_5 buf
+      | 3 -> (Sedlexing.__private__set_mem_pos buf 3; __sedlex_state_2 buf)
+      | 4 -> (Sedlexing.__private__set_mem_pos buf 2; __sedlex_state_1 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_1 buf =
-      match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_2 buf
-      | _ -> Sedlexing.backtrack buf
+      Sedlexing.mark buf 4;
+      (match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
+       | 0 -> __sedlex_state_6 buf
+       | 1 -> (Sedlexing.__private__set_mem_pos buf 2; __sedlex_state_1 buf)
+       | _ -> Sedlexing.backtrack buf)
     and __sedlex_state_2 buf =
       match __sedlex_partition_3 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_3 buf
+      | 0 -> __sedlex_state_7 buf
+      | 1 -> (Sedlexing.__private__set_mem_pos buf 3; __sedlex_state_2 buf)
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_3 buf =
-      match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_4 buf
-      | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_4 buf =
-      match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
-      | 0 -> 3
-      | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_6 buf =
       Sedlexing.mark buf 4;
-      (match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
-       | 0 -> __sedlex_state_7 buf
+      (match __sedlex_partition_4 (Sedlexing.__private__next_int buf) with
+       | 0 -> __sedlex_state_5 buf
        | 1 -> __sedlex_state_8 buf
        | _ -> Sedlexing.backtrack buf)
-    and __sedlex_state_7 buf =
+    and __sedlex_state_4 buf =
+      match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_9 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_5 buf =
       Sedlexing.mark buf 4;
       (match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
-       | 0 -> __sedlex_state_7 buf
+       | 0 -> __sedlex_state_5 buf
        | _ -> Sedlexing.backtrack buf)
+    and __sedlex_state_6 buf =
+      match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_10 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_7 buf =
+      match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_11 buf
+      | _ -> Sedlexing.backtrack buf
     and __sedlex_state_8 buf =
       match __sedlex_partition_7 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_9 buf
+      | 0 -> __sedlex_state_12 buf
       | _ -> Sedlexing.backtrack buf
     and __sedlex_state_9 buf =
       match __sedlex_partition_8 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_9 buf
-      | 1 -> 2
-      | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_11 buf =
-      match __sedlex_partition_9 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_12 buf
-      | 1 -> (Sedlexing.__private__set_mem_pos buf 1; __sedlex_state_11 buf)
-      | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_12 buf =
-      match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
       | 0 -> __sedlex_state_13 buf
       | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_13 buf =
+    and __sedlex_state_10 buf =
+      Sedlexing.__private__copy_mem buf 0 2;
+      Sedlexing.mark buf 0;
+      (match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
+       | 0 -> __sedlex_state_10 buf
+       | _ -> Sedlexing.backtrack buf)
+    and __sedlex_state_11 buf =
+      Sedlexing.__private__copy_mem buf 1 3;
       Sedlexing.mark buf 1;
       (match __sedlex_partition_6 (Sedlexing.__private__next_int buf) with
-       | 0 -> __sedlex_state_13 buf
+       | 0 -> __sedlex_state_11 buf
        | _ -> Sedlexing.backtrack buf)
-    and __sedlex_state_14 buf =
-      Sedlexing.mark buf 4;
-      (match __sedlex_partition_10 (Sedlexing.__private__next_int buf) with
-       | 0 -> __sedlex_state_15 buf
-       | 1 -> (Sedlexing.__private__set_mem_pos buf 0; __sedlex_state_14 buf)
-       | _ -> Sedlexing.backtrack buf)
-    and __sedlex_state_15 buf =
-      match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-      | 0 -> __sedlex_state_16 buf
+    and __sedlex_state_12 buf =
+      match __sedlex_partition_9 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_12 buf
+      | 1 -> 2
       | _ -> Sedlexing.backtrack buf
-    and __sedlex_state_16 buf =
-      Sedlexing.mark buf 0;
-      (match __sedlex_partition_2 (Sedlexing.__private__next_int buf) with
-       | 0 -> __sedlex_state_16 buf
-       | _ -> Sedlexing.backtrack buf) in
+    and __sedlex_state_13 buf =
+      match __sedlex_partition_5 (Sedlexing.__private__next_int buf) with
+      | 0 -> __sedlex_state_15 buf
+      | _ -> Sedlexing.backtrack buf
+    and __sedlex_state_15 buf =
+      match __sedlex_partition_10 (Sedlexing.__private__next_int buf) with
+      | 0 -> 3
+      | _ -> Sedlexing.backtrack buf in
     match Sedlexing.start buf;
-          Sedlexing.__private__init_mem buf 2;
+          Sedlexing.__private__init_mem buf 4;
           __sedlex_state_0 buf
     with
     | 0 ->

--- a/test/oracle/dune
+++ b/test/oracle/dune
@@ -1,0 +1,8 @@
+(library
+ (name oracle_test)
+ (libraries sedlex.compiler qcheck-core)
+ (inline_tests)
+ (enabled_if
+  (>= %{ocaml_version} 4.14))
+ (preprocess
+  (pps ppx_expect)))

--- a/test/oracle/oracle.ml
+++ b/test/oracle/oracle.ml
@@ -207,7 +207,8 @@ let dfa_match (compiled : Sedlex.compiled_ir) (input : int array) :
       (fun (op : Sedlex.tag_op) ->
         match op with
           | Set_position t -> mem.(t) <- pos
-          | Set_value (cell, v) -> mem.(cell) <- v)
+          | Set_value (cell, v) -> mem.(cell) <- v
+          | Copy (dst, src) -> mem.(dst) <- mem.(src))
       ops
   in
   apply 0 compiled.init_tags;

--- a/test/oracle/oracle.ml
+++ b/test/oracle/oracle.ml
@@ -216,7 +216,10 @@ let dfa_match (compiled : Sedlex.compiled_ir) (input : int array) :
   let rec loop state pos =
     let st = compiled.dfa.(state) in
     (match best_final st.finals with
-      | Some r -> marked := Some (r, pos, Array.copy mem)
+      | Some r ->
+          (* Materialize registers into canonical cells, then mark. *)
+          apply pos st.final_ops;
+          marked := Some (r, pos, Array.copy mem)
       | None -> ());
     if pos <= len then (
       (* At end of input the runtime feeds the EOF code point (-1). *)

--- a/test/oracle/oracle.ml
+++ b/test/oracle/oracle.ml
@@ -212,15 +212,15 @@ let dfa_match (compiled : Sedlex.compiled_ir) (input : int array) :
     let saved =
       List.filter_map
         (fun (op : Sedlex.tag_op) ->
-          match op with Copy (_, src) -> Some (src, mem.(src)) | _ -> None)
+          match op with Copy { src; _ } -> Some (src, mem.(src)) | _ -> None)
         ops
     in
     List.iter
       (fun (op : Sedlex.tag_op) ->
         match op with
-          | Set_position t -> mem.(t) <- pos
-          | Set_value (cell, v) -> mem.(cell) <- v
-          | Copy (dst, src) -> mem.(dst) <- List.assoc src saved)
+          | Set_position { dst } -> mem.(dst) <- pos
+          | Set_value { dst; value } -> mem.(dst) <- value
+          | Copy { dst; src } -> mem.(dst) <- List.assoc src saved)
       ops
   in
   apply 0 compiled.init_tags;

--- a/test/oracle/oracle.ml
+++ b/test/oracle/oracle.ml
@@ -69,7 +69,8 @@ type match_result = {
    order. Captures cannot occur under repetition (enforced by the Ir smart
    constructors), so repetition bodies never extend the environment and
    iterations that consume nothing can be cut without losing bindings. *)
-let parses (ir : Ir.t) (input : int array) : (int * (string * (int * int)) list) Seq.t =
+let parses (ir : Ir.t) (input : int array) :
+    (int * (string * (int * int)) list) Seq.t =
   let len = Array.length input in
   let rec go ir pos env =
     match ir with
@@ -105,7 +106,8 @@ let parses (ir : Ir.t) (input : int array) : (int * (string * (int * int)) list)
     else
       Seq.append
         (Seq.concat_map
-           (fun (p, e) -> if p = pos then Seq.empty else bounded r 0 (m - 1) p e)
+           (fun (p, e) ->
+             if p = pos then Seq.empty else bounded r 0 (m - 1) p e)
            (go r pos env))
         (Seq.return (pos, env))
   in
@@ -116,9 +118,7 @@ let parses (ir : Ir.t) (input : int array) : (int * (string * (int * int)) list)
 let best_parse ir input =
   Seq.fold_left
     (fun best (p, e) ->
-      match best with
-        | Some (bp, _) when bp >= p -> best
-        | _ -> Some (p, e))
+      match best with Some (bp, _) when bp >= p -> best | _ -> Some (p, e))
     None (parses ir input)
 
 let ref_match (rules : Ir.t array) (input : int array) : match_result option =
@@ -129,7 +129,7 @@ let ref_match (rules : Ir.t array) (input : int array) : match_result option =
         | None -> ()
         | Some (p, e) -> (
             (* Longest match wins; the lowest-numbered rule wins ties. *)
-            match !best with
+              match !best with
               | Some (_, bp, _) when bp >= p -> ()
               | _ -> best := Some (i, p, e)))
     rules;
@@ -158,7 +158,9 @@ let ref_match (rules : Ir.t array) (input : int array) : match_result option =
 
 let best_final finals =
   let n = Array.length finals in
-  let rec aux i = if i = n then None else if finals.(i) then Some i else aux (i + 1) in
+  let rec aux i =
+    if i = n then None else if finals.(i) then Some i else aux (i + 1)
+  in
   aux 0
 
 let eval_pos mem ~len (pe : Sedlex.pos_expr) =
@@ -185,7 +187,9 @@ let extract_bindings (bindings : Sedlex.compiled_binding list) mem ~len =
     (List.map
        (fun name ->
          let entries =
-           List.filter (fun (b : Sedlex.compiled_binding) -> b.name = name) bindings
+           List.filter
+             (fun (b : Sedlex.compiled_binding) -> b.name = name)
+             bindings
          in
          let rec select = function
            | [] -> assert false
@@ -208,9 +212,7 @@ let dfa_match (compiled : Sedlex.compiled_ir) (input : int array) :
     let saved =
       List.filter_map
         (fun (op : Sedlex.tag_op) ->
-          match op with
-            | Copy (_, src) -> Some (src, mem.(src))
-            | _ -> None)
+          match op with Copy (_, src) -> Some (src, mem.(src)) | _ -> None)
         ops
     in
     List.iter
@@ -251,7 +253,11 @@ let dfa_match (compiled : Sedlex.compiled_ir) (input : int array) :
   loop 0 0;
   Option.map
     (fun (r, p, m) ->
-      { rule = r; len = p; bindings = extract_bindings compiled.bindings.(r) m ~len:p })
+      {
+        rule = r;
+        len = p;
+        bindings = extract_bindings compiled.bindings.(r) m ~len:p;
+      })
     !marked
 
 (* ------------------------------------------------------------------ *)
@@ -270,14 +276,17 @@ let show_result input (r : match_result option) =
             (fun i (name, (s, e)) ->
               if i > 0 then Buffer.add_string buf ", ";
               match (s, e) with
-                | Some s, Some e when 0 <= s && s <= e && e <= Array.length input
-                  ->
+                | Some s, Some e
+                  when 0 <= s && s <= e && e <= Array.length input ->
                     Printf.bprintf buf "%s=%S" name
                       (String.init (e - s) (fun i ->
                            let c = input.(s + i) in
                            if c >= 32 && c < 127 then Char.chr c else '?'))
                 | s, e ->
-                    let p = function None -> "unset" | Some n -> string_of_int n in
+                    let p = function
+                      | None -> "unset"
+                      | Some n -> string_of_int n
+                    in
                     Printf.bprintf buf "%s=<%s..%s>" name (p s) (p e))
             bindings;
           Buffer.add_string buf "]");
@@ -286,8 +295,7 @@ let show_result input (r : match_result option) =
 let codes s = Array.init (String.length s) (fun i -> Char.code s.[i])
 
 let compile rules =
-  try Ok (Sedlex.compile_ir rules)
-  with exn -> Error (Printexc.to_string exn)
+  try Ok (Sedlex.compile_ir rules) with exn -> Error (Printexc.to_string exn)
 
 let oracle rules input_str =
   let input = codes input_str in
@@ -355,7 +363,9 @@ let names = [| "x"; "y"; "z"; "w" |]
    under repetition), each binding a distinct name. *)
 let gen_rule =
   G.bind (G.int_range 1 4) (fun n ->
-      G.bind (G.int_range 0 (n - 1)) (fun cap_at ->
+      G.bind
+        (G.int_range 0 (n - 1))
+        (fun cap_at ->
           let gen_elem i =
             let simple = G.bind (G.int_range 0 2) gen_simple in
             if i = cap_at then G.map (capture names.(i)) simple

--- a/test/oracle/oracle.ml
+++ b/test/oracle/oracle.ml
@@ -166,7 +166,9 @@ let ref_match (rules : Ir.t array) (input : int array) : match_result option =
      memory cells are saved ([Sedlexing.mark]);
    - a transition's tag operations run after the code point is consumed, so
      [Set_position] records the position just past that code point;
-   - on a dead end, the last saved snapshot wins ([Sedlexing.backtrack]). *)
+   - a mark is kept only when it improves on the current one — strictly longer,
+     or equal length with a lower rule number ([Sedlexing.mark]);
+   - on a dead end, the last kept snapshot wins ([Sedlexing.backtrack]). *)
 
 let eval_pos mem ~len (pe : Sedlex.pos_expr) =
   match pe with
@@ -246,9 +248,16 @@ let dfa_match (compiled : Sedlex.compiled_ir) (input : int array) :
     let st = compiled.dfa.(state) in
     (match st.accept with
       | Some (r, ops) ->
-          (* Materialize registers into canonical cells, then mark. *)
+          (* Materialize registers into canonical cells (final_ops always run),
+             then keep the mark only if it improves on the current one — longer,
+             or equal length with a lower rule number. *)
           apply pos ops;
-          marked := Some (r, pos, Array.copy mem)
+          let improves =
+            match !marked with
+              | None -> true
+              | Some (mr, mp, _) -> pos > mp || (pos = mp && r < mr)
+          in
+          if improves then marked := Some (r, pos, Array.copy mem)
       | None -> ());
     if pos < len then (
       match transition st input.(pos) with
@@ -419,10 +428,10 @@ let gen_or_rule =
   let branch = G.bind (G.int_range 0 2) gen_simple in
   G.map2 (fun a b -> alt (capture "x" a) (capture "x" b)) branch branch
 
-(* Single-rule sweeps exercise the terminal [eof] anchor (regression coverage
-   for the fixed_length eof-width bug); multi-rule sweeps omit it to avoid the
-   separate eof/rule-priority interaction (a zero-width eof mark can re-mark at
-   the same position and flip which same-length rule wins). *)
+(* The terminal [eof] anchor gives regression coverage for both the
+   fixed_length eof-width bug and the eof/rule-priority tie (an earlier rule and
+   a later [eof]-terminated rule matching the same length: the earlier rule must
+   win). *)
 let gen_ir ?eof () = G.oneof_weighted [(4, gen_rule ?eof ()); (1, gen_or_rule)]
 let gen_input = G.string_size ~gen:gen_char (G.int_range 0 5)
 

--- a/test/oracle/oracle.ml
+++ b/test/oracle/oracle.ml
@@ -31,6 +31,8 @@ open Sedlex_compiler
 let ok = function Ok x -> x | Error e -> failwith e
 let lit c = Ir.chars (Cset.singleton (Char.code c))
 let cls lo hi = Ir.chars (Cset.interval (Char.code lo) (Char.code hi))
+let eof = Ir.chars Cset.eof
+let any = Ir.chars Cset.any
 let seq r1 r2 = ok (Ir.seq r1 r2)
 let ( ^. ) = seq
 let alt r1 r2 = ok (Ir.alt r1 r2)
@@ -75,8 +77,18 @@ let parses (ir : Ir.t) (input : int array) :
   let rec go ir pos env =
     match ir with
       | Ir.Chars cs ->
-          if pos < len && Cset.mem input.(pos) cs then Seq.return (pos + 1, env)
-          else Seq.empty
+          (* A real character consumes one position; the eof pseudo-character
+             (-1) matches only at end of input and consumes nothing, mirroring
+             the runtime where [next] reports EOF without advancing [pos]. *)
+          let real =
+            if pos < len && Cset.mem input.(pos) cs then Seq.return (pos + 1, env)
+            else Seq.empty
+          in
+          let eof =
+            if pos = len && Cset.mem (-1) cs then Seq.return (pos, env)
+            else Seq.empty
+          in
+          Seq.append real eof
       | Ir.Eps -> Seq.return (pos, env)
       | Ir.Seq elems ->
           List.fold_left
@@ -225,7 +237,19 @@ let dfa_match (compiled : Sedlex.compiled_ir) (input : int array) :
   in
   apply 0 compiled.init_tags;
   let marked = ref None in
-  let rec loop state pos =
+  let transition (st : Sedlex.dfa_state) ch =
+    Array.fold_left
+      (fun acc (cs, tgt, ops) ->
+        match acc with
+          | Some _ -> acc
+          | None -> if Cset.mem ch cs then Some (tgt, ops) else None)
+      None st.trans
+  in
+  (* [eofed] records whether the EOF pseudo-character has already been fed.
+     The runtime reports EOF (-1) without advancing [pos], so the eof edge is
+     zero-width; the flag stops us from re-feeding it forever on an eof
+     self-loop. *)
+  let rec loop state pos eofed =
     let st = compiled.dfa.(state) in
     (match best_final st.finals with
       | Some r ->
@@ -233,24 +257,21 @@ let dfa_match (compiled : Sedlex.compiled_ir) (input : int array) :
           apply pos st.final_ops;
           marked := Some (r, pos, Array.copy mem)
       | None -> ());
-    if pos <= len then (
-      (* At end of input the runtime feeds the EOF code point (-1). *)
-      let ch = if pos < len then input.(pos) else -1 in
-      let tr =
-        Array.fold_left
-          (fun acc (cs, tgt, ops) ->
-            match acc with
-              | Some _ -> acc
-              | None -> if Cset.mem ch cs then Some (tgt, ops) else None)
-          None st.trans
-      in
-      match tr with
+    if pos < len then (
+      match transition st input.(pos) with
         | None -> ()
         | Some (tgt, ops) ->
             apply (pos + 1) ops;
-            loop tgt (pos + 1))
+            loop tgt (pos + 1) eofed)
+    else if not eofed then (
+      (* End of input: feed EOF (-1) as a zero-width step. *)
+      match transition st (-1) with
+        | None -> ()
+        | Some (tgt, ops) ->
+            apply pos ops;
+            loop tgt pos true)
   in
-  loop 0 0;
+  loop 0 0 false;
   Option.map
     (fun (r, p, m) ->
       {
@@ -336,6 +357,22 @@ let gen_cset =
         gen_char gen_char;
     ]
 
+(* A terminal end-of-input anchor: nothing, a bare [eof], or a data-dependent
+   [c | eof] cset. Placed only at the end of a rule, where [eof] realistically
+   appears; this exercises the zero-width eof paths (offset math across eof,
+   mixed-width csets) without generating degenerate eof-in-the-middle shapes. *)
+let gen_eof_anchor =
+  G.oneof_weighted
+    [
+      (3, G.pure None);
+      (1, G.pure (Some (Ir.chars Cset.eof)));
+      ( 1,
+        G.map
+          (fun c ->
+            Some (Ir.chars (Cset.union (Cset.singleton (Char.code c)) Cset.eof)))
+          gen_char );
+    ]
+
 (* Capture-free regexp of bounded depth. *)
 let rec gen_simple depth =
   if depth = 0 then G.map Ir.chars gen_cset
@@ -361,7 +398,7 @@ let names = [| "x"; "y"; "z"; "w" |]
 (* A rule: a sequence of up to 4 elements with at least one capture. Captures
    sit at the top level of the sequence (the Ir smart constructors reject them
    under repetition), each binding a distinct name. *)
-let gen_rule =
+let gen_rule ?(eof = false) () =
   G.bind (G.int_range 1 4) (fun n ->
       G.bind
         (G.int_range 0 (n - 1))
@@ -376,14 +413,24 @@ let gen_rule =
           let rec build i acc =
             if i = n then acc else build (i + 1) (G.map2 seq acc (gen_elem i))
           in
-          build 1 (gen_elem 0)))
+          let body = build 1 (gen_elem 0) in
+          if not eof then body
+          else
+            G.map2
+              (fun body anchor ->
+                match anchor with Some a -> seq body a | None -> body)
+              body gen_eof_anchor))
 
 (* An or-pattern rule: both branches bind the same name (discriminators). *)
 let gen_or_rule =
   let branch = G.bind (G.int_range 0 2) gen_simple in
   G.map2 (fun a b -> alt (capture "x" a) (capture "x" b)) branch branch
 
-let gen_ir = G.oneof_weighted [(4, gen_rule); (1, gen_or_rule)]
+(* Single-rule sweeps exercise the terminal [eof] anchor (regression coverage
+   for the fixed_length eof-width bug); multi-rule sweeps omit it to avoid the
+   separate eof/rule-priority interaction (a zero-width eof mark can re-mark at
+   the same position and flip which same-length rule wins). *)
+let gen_ir ?eof () = G.oneof_weighted [(4, gen_rule ?eof ()); (1, gen_or_rule)]
 let gen_input = G.string_size ~gen:gen_char (G.int_range 0 5)
 
 (* Deterministic property runner: fixed seed, no shrinking. Failing cases are

--- a/test/oracle/oracle.ml
+++ b/test/oracle/oracle.ml
@@ -1,0 +1,383 @@
+(* The package sedlex is released under the terms of an MIT-like license. *)
+(* See the attached LICENSE file.                                         *)
+(* Copyright 2026, Hugo Heuzard                                           *)
+
+(** Test oracle for the tagged-DFA compiler.
+
+    Two independent implementations of sedlex's matching semantics are run on
+    the same (rules, input) pairs and their results compared:
+
+    - {!ref_match}: a brute-force backtracking matcher over {!Ir.t}. It
+      enumerates parses in leftmost-greedy priority order (alternation prefers
+      the left branch, repetition prefers more iterations) and keeps the
+      highest-priority parse among those of maximal length. This is the
+      specification of capture semantics.
+
+    - {!dfa_match}: an interpreter for the output of {!Sedlex.compile_ir} that
+      faithfully replicates the runtime behavior of PPX-generated code:
+      mark/backtrack with memory-cell snapshots, tag operations on transitions,
+      and binding extraction via discriminator cells.
+
+    {!oracle} prints one line per input, prefixed with ERROR when the two
+    disagree. {!qcheck} runs a deterministic random sweep and prints failing
+    cases through {!oracle}, so an empty expect block means full agreement. *)
+
+open Sedlex_compiler
+
+(* ------------------------------------------------------------------ *)
+(* Ir combinators                                                      *)
+(* ------------------------------------------------------------------ *)
+
+let ok = function Ok x -> x | Error e -> failwith e
+let lit c = Ir.chars (Cset.singleton (Char.code c))
+let cls lo hi = Ir.chars (Cset.interval (Char.code lo) (Char.code hi))
+let seq r1 r2 = ok (Ir.seq r1 r2)
+let ( ^. ) = seq
+let alt r1 r2 = ok (Ir.alt r1 r2)
+let star r = ok (Ir.star r)
+let plus r = ok (Ir.plus r)
+let rep r n m = ok (Ir.rep r n m)
+let opt r = rep r 0 1
+let capture name r = ok (Ir.capture name r)
+
+let cset_of = function
+  | Ir.Chars c -> c
+  | _ -> failwith "single-character regexp expected"
+
+let compl r = Ir.chars (Cset.difference Cset.any (cset_of r))
+let sub r1 r2 = Ir.chars (Cset.difference (cset_of r1) (cset_of r2))
+let inter r1 r2 = Ir.chars (Cset.intersection (cset_of r1) (cset_of r2))
+
+(* ------------------------------------------------------------------ *)
+(* Common result shape                                                 *)
+(* ------------------------------------------------------------------ *)
+
+type match_result = {
+  rule : int;
+  len : int;
+  bindings : (string * (int option * int option)) list;
+      (** Sorted by name. [None] means the position comes from a memory cell
+          that was never written (only the DFA side can produce this). *)
+}
+
+(* ------------------------------------------------------------------ *)
+(* Reference matcher                                                   *)
+(* ------------------------------------------------------------------ *)
+
+(* [parses ir input] lazily enumerates the (end position, capture environment)
+   of every parse of [ir] starting at position 0, in leftmost-greedy priority
+   order. Captures cannot occur under repetition (enforced by the Ir smart
+   constructors), so repetition bodies never extend the environment and
+   iterations that consume nothing can be cut without losing bindings. *)
+let parses (ir : Ir.t) (input : int array) : (int * (string * (int * int)) list) Seq.t =
+  let len = Array.length input in
+  let rec go ir pos env =
+    match ir with
+      | Ir.Chars cs ->
+          if pos < len && Cset.mem input.(pos) cs then Seq.return (pos + 1, env)
+          else Seq.empty
+      | Ir.Eps -> Seq.return (pos, env)
+      | Ir.Seq elems ->
+          List.fold_left
+            (fun acc elem -> Seq.concat_map (fun (p, e) -> go elem p e) acc)
+            (Seq.return (pos, env))
+            elems
+      | Ir.Alt branches ->
+          Seq.concat_map (fun b -> go b pos env) (List.to_seq branches)
+      | Ir.Star r -> iter r pos env
+      | Ir.Plus r -> Seq.concat_map (fun (p, e) -> iter r p e) (go r pos env)
+      | Ir.Rep (r, n, m) -> bounded r n m pos env
+      | Ir.Capture (name, r) ->
+          Seq.map (fun (p, e) -> (p, (name, (pos, p)) :: e)) (go r pos env)
+  and iter r pos env =
+    (* Greedy: continuing the loop has priority over exiting. *)
+    Seq.append
+      (Seq.concat_map
+         (fun (p, e) -> if p = pos then Seq.empty else iter r p e)
+         (go r pos env))
+      (Seq.return (pos, env))
+  and bounded r n m pos env =
+    if m = 0 then Seq.return (pos, env)
+    else if n > 0 then
+      Seq.concat_map
+        (fun (p, e) -> bounded r (n - 1) (m - 1) p e)
+        (go r pos env)
+    else
+      Seq.append
+        (Seq.concat_map
+           (fun (p, e) -> if p = pos then Seq.empty else bounded r 0 (m - 1) p e)
+           (go r pos env))
+        (Seq.return (pos, env))
+  in
+  go ir 0 []
+
+(* Highest-priority parse among those of maximal length: enumeration order is
+   priority order, so the first parse reaching the maximum wins ties. *)
+let best_parse ir input =
+  Seq.fold_left
+    (fun best (p, e) ->
+      match best with
+        | Some (bp, _) when bp >= p -> best
+        | _ -> Some (p, e))
+    None (parses ir input)
+
+let ref_match (rules : Ir.t array) (input : int array) : match_result option =
+  let best = ref None in
+  Array.iteri
+    (fun i ir ->
+      match best_parse ir input with
+        | None -> ()
+        | Some (p, e) -> (
+            (* Longest match wins; the lowest-numbered rule wins ties. *)
+            match !best with
+              | Some (_, bp, _) when bp >= p -> ()
+              | _ -> best := Some (i, p, e)))
+    rules;
+  Option.map
+    (fun (i, p, e) ->
+      let bindings =
+        List.sort compare
+          (List.map (fun (n, (s, ep)) -> (n, (Some s, Some ep))) e)
+      in
+      { rule = i; len = p; bindings })
+    !best
+
+(* ------------------------------------------------------------------ *)
+(* DFA interpreter                                                     *)
+(* ------------------------------------------------------------------ *)
+
+(* Replicates the runtime behavior of PPX-generated code (see [gen_state] and
+   [gen_definition] in ppx_sedlex.ml):
+   - memory cells start at -1 ([__private__init_mem]);
+   - [init_tags] run before entering state 0, recording position 0;
+   - on entering an accepting state, the rule, position and a snapshot of the
+     memory cells are saved ([Sedlexing.mark]);
+   - a transition's tag operations run after the code point is consumed, so
+     [Set_position] records the position just past that code point;
+   - on a dead end, the last saved snapshot wins ([Sedlexing.backtrack]). *)
+
+let best_final finals =
+  let n = Array.length finals in
+  let rec aux i = if i = n then None else if finals.(i) then Some i else aux (i + 1) in
+  aux 0
+
+let eval_pos mem ~len (pe : Sedlex.pos_expr) =
+  match pe with
+    | Sedlex.Tag { tag; offset } ->
+        let v = mem.(tag) in
+        if v < 0 then None else Some (v + offset)
+    | Sedlex.Start_plus n -> Some n
+    | Sedlex.End_minus n -> Some (len - n)
+
+(* Mirrors [gen_binding_code]: bindings are grouped by name; for a name with
+   several (start, end, disc) alternatives the generated code emits an if/else
+   chain on the discriminator cells, falling through to the last alternative
+   unconditionally. *)
+let extract_bindings (bindings : Sedlex.compiled_binding list) mem ~len =
+  let names =
+    List.rev
+      (List.fold_left
+         (fun acc (b : Sedlex.compiled_binding) ->
+           if List.mem b.name acc then acc else b.name :: acc)
+         [] bindings)
+  in
+  List.sort compare
+    (List.map
+       (fun name ->
+         let entries =
+           List.filter (fun (b : Sedlex.compiled_binding) -> b.name = name) bindings
+         in
+         let rec select = function
+           | [] -> assert false
+           | [(b : Sedlex.compiled_binding)] -> b
+           | (b : Sedlex.compiled_binding) :: rest ->
+               if List.for_all (fun (cell, v) -> mem.(cell) = v) b.disc then b
+               else select rest
+         in
+         let b = select entries in
+         (name, (eval_pos mem ~len b.start_pos, eval_pos mem ~len b.end_pos)))
+       names)
+
+let dfa_match (compiled : Sedlex.compiled_ir) (input : int array) :
+    match_result option =
+  let len = Array.length input in
+  let mem = Array.make (max compiled.num_tags 0) (-1) in
+  let apply pos ops =
+    List.iter
+      (fun (op : Sedlex.tag_op) ->
+        match op with
+          | Set_position t -> mem.(t) <- pos
+          | Set_value (cell, v) -> mem.(cell) <- v)
+      ops
+  in
+  apply 0 compiled.init_tags;
+  let marked = ref None in
+  let rec loop state pos =
+    let st = compiled.dfa.(state) in
+    (match best_final st.finals with
+      | Some r -> marked := Some (r, pos, Array.copy mem)
+      | None -> ());
+    if pos <= len then (
+      (* At end of input the runtime feeds the EOF code point (-1). *)
+      let ch = if pos < len then input.(pos) else -1 in
+      let tr =
+        Array.fold_left
+          (fun acc (cs, tgt, ops) ->
+            match acc with
+              | Some _ -> acc
+              | None -> if Cset.mem ch cs then Some (tgt, ops) else None)
+          None st.trans
+      in
+      match tr with
+        | None -> ()
+        | Some (tgt, ops) ->
+            apply (pos + 1) ops;
+            loop tgt (pos + 1))
+  in
+  loop 0 0;
+  Option.map
+    (fun (r, p, m) ->
+      { rule = r; len = p; bindings = extract_bindings compiled.bindings.(r) m ~len:p })
+    !marked
+
+(* ------------------------------------------------------------------ *)
+(* Comparison and printing                                             *)
+(* ------------------------------------------------------------------ *)
+
+let show_result input (r : match_result option) =
+  match r with
+    | None -> "no match"
+    | Some { rule; len; bindings } ->
+        let buf = Buffer.create 32 in
+        Printf.bprintf buf "rule %d, len %d" rule len;
+        if bindings <> [] then (
+          Buffer.add_string buf ", [";
+          List.iteri
+            (fun i (name, (s, e)) ->
+              if i > 0 then Buffer.add_string buf ", ";
+              match (s, e) with
+                | Some s, Some e when 0 <= s && s <= e && e <= Array.length input
+                  ->
+                    Printf.bprintf buf "%s=%S" name
+                      (String.init (e - s) (fun i ->
+                           let c = input.(s + i) in
+                           if c >= 32 && c < 127 then Char.chr c else '?'))
+                | s, e ->
+                    let p = function None -> "unset" | Some n -> string_of_int n in
+                    Printf.bprintf buf "%s=<%s..%s>" name (p s) (p e))
+            bindings;
+          Buffer.add_string buf "]");
+        Buffer.contents buf
+
+let codes s = Array.init (String.length s) (fun i -> Char.code s.[i])
+
+let compile rules =
+  try Ok (Sedlex.compile_ir rules)
+  with exn -> Error (Printexc.to_string exn)
+
+let oracle rules input_str =
+  let input = codes input_str in
+  let ref_s = show_result input (ref_match rules input) in
+  match compile rules with
+    | Error e -> Printf.printf "ERROR %S -> compile_ir raised: %s\n" input_str e
+    | Ok compiled ->
+        let dfa_s = show_result input (dfa_match compiled input) in
+        if String.equal ref_s dfa_s then
+          Printf.printf "%S -> %s\n" input_str ref_s
+        else Printf.printf "ERROR %S -> ref=%s dfa=%s\n" input_str ref_s dfa_s
+
+let check rules input_str =
+  let input = codes input_str in
+  match compile rules with
+    | Error _ -> false
+    | Ok compiled ->
+        String.equal
+          (show_result input (ref_match rules input))
+          (show_result input (dfa_match compiled input))
+
+(* ------------------------------------------------------------------ *)
+(* Random pattern generation                                           *)
+(* ------------------------------------------------------------------ *)
+
+module G = QCheck2.Gen
+
+let gen_char = G.char_range 'a' 'd'
+
+let gen_cset =
+  G.oneof
+    [
+      G.map (fun c -> Cset.singleton (Char.code c)) gen_char;
+      G.map2
+        (fun a b ->
+          let a = Char.code a and b = Char.code b in
+          Cset.interval (min a b) (max a b))
+        gen_char gen_char;
+    ]
+
+(* Capture-free regexp of bounded depth. *)
+let rec gen_simple depth =
+  if depth = 0 then G.map Ir.chars gen_cset
+  else (
+    let sub = gen_simple (depth - 1) in
+    G.oneof_weighted
+      [
+        (3, G.map Ir.chars gen_cset);
+        (2, G.map2 seq sub sub);
+        (2, G.map2 alt sub sub);
+        (1, G.map star sub);
+        (1, G.map plus sub);
+        ( 1,
+          G.map2
+            (fun r (n, m) -> rep r n m)
+            sub
+            (G.map2 (fun n k -> (n, n + k)) (G.int_range 0 2) (G.int_range 0 2))
+        );
+      ])
+
+let names = [| "x"; "y"; "z"; "w" |]
+
+(* A rule: a sequence of up to 4 elements with at least one capture. Captures
+   sit at the top level of the sequence (the Ir smart constructors reject them
+   under repetition), each binding a distinct name. *)
+let gen_rule =
+  G.bind (G.int_range 1 4) (fun n ->
+      G.bind (G.int_range 0 (n - 1)) (fun cap_at ->
+          let gen_elem i =
+            let simple = G.bind (G.int_range 0 2) gen_simple in
+            if i = cap_at then G.map (capture names.(i)) simple
+            else
+              G.oneof_weighted
+                [(3, simple); (1, G.map (capture names.(i)) simple)]
+          in
+          let rec build i acc =
+            if i = n then acc else build (i + 1) (G.map2 seq acc (gen_elem i))
+          in
+          build 1 (gen_elem 0)))
+
+(* An or-pattern rule: both branches bind the same name (discriminators). *)
+let gen_or_rule =
+  let branch = G.bind (G.int_range 0 2) gen_simple in
+  G.map2 (fun a b -> alt (capture "x" a) (capture "x" b)) branch branch
+
+let gen_ir = G.oneof_weighted [(4, gen_rule); (1, gen_or_rule)]
+let gen_input = G.string_size ~gen:gen_char (G.int_range 0 5)
+
+(* Deterministic property runner: fixed seed, no shrinking. Failing cases are
+   printed through [oracle] so expect blocks capture them; an empty expect
+   block means reference and DFA agree on every generated case. *)
+let qcheck ?(count = 2000) ?(max_print = 5) gen =
+  let rand = Random.State.make [| 0x5ed1ec5 |] in
+  let failures = ref 0 in
+  for _ = 1 to count do
+    let rules, input = G.generate1 ~rand gen in
+    if not (check rules input) then (
+      incr failures;
+      if !failures <= max_print then (
+        Array.iteri
+          (fun i ir -> Printf.printf "  rule%d: %s\n" i (Ir.show ir))
+          rules;
+        oracle rules input))
+  done;
+  if !failures > 0 then
+    Printf.printf "%d/%d cases failed (printed at most %d)\n" !failures count
+      max_print

--- a/test/oracle/oracle.ml
+++ b/test/oracle/oracle.ml
@@ -203,12 +203,22 @@ let dfa_match (compiled : Sedlex.compiled_ir) (input : int array) :
   let len = Array.length input in
   let mem = Array.make (max compiled.num_tags 0) (-1) in
   let apply pos ops =
+    (* Parallel-move semantics: Copy reads observe the state before any
+       write of the same operation list. *)
+    let saved =
+      List.filter_map
+        (fun (op : Sedlex.tag_op) ->
+          match op with
+            | Copy (_, src) -> Some (src, mem.(src))
+            | _ -> None)
+        ops
+    in
     List.iter
       (fun (op : Sedlex.tag_op) ->
         match op with
           | Set_position t -> mem.(t) <- pos
           | Set_value (cell, v) -> mem.(cell) <- v
-          | Copy (dst, src) -> mem.(dst) <- mem.(src))
+          | Copy (dst, src) -> mem.(dst) <- List.assoc src saved)
       ops
   in
   apply 0 compiled.init_tags;

--- a/test/oracle/oracle.ml
+++ b/test/oracle/oracle.ml
@@ -168,13 +168,6 @@ let ref_match (rules : Ir.t array) (input : int array) : match_result option =
      [Set_position] records the position just past that code point;
    - on a dead end, the last saved snapshot wins ([Sedlexing.backtrack]). *)
 
-let best_final finals =
-  let n = Array.length finals in
-  let rec aux i =
-    if i = n then None else if finals.(i) then Some i else aux (i + 1)
-  in
-  aux 0
-
 let eval_pos mem ~len (pe : Sedlex.pos_expr) =
   match pe with
     | Sedlex.Tag { tag; offset } ->
@@ -251,10 +244,10 @@ let dfa_match (compiled : Sedlex.compiled_ir) (input : int array) :
      self-loop. *)
   let rec loop state pos eofed =
     let st = compiled.dfa.(state) in
-    (match best_final st.finals with
-      | Some r ->
+    (match st.accept with
+      | Some (r, ops) ->
           (* Materialize registers into canonical cells, then mark. *)
-          apply pos st.final_ops;
+          apply pos ops;
           marked := Some (r, pos, Array.copy mem)
       | None -> ());
     if pos < len then (

--- a/test/oracle/test_oracle.ml
+++ b/test/oracle/test_oracle.ml
@@ -138,7 +138,7 @@ let%expect_test "Rep greedy disambiguation" =
   oracle [| capture "z" (rep (cls 'a' 'c') 0 2) ^. lit 'a' |] "aaa";
   [%expect {|
     "aaa" -> rule 0, len 3, [z="aa"]
-    ERROR "aa" -> ref=rule 0, len 2, [z="a"] dfa=rule 0, len 2, [z="aa"]
+    "aa" -> rule 0, len 2, [z="a"]
     "aa" -> rule 0, len 2, [z="a"]
     "aaa" -> rule 0, len 3, [z="aa"]
     |}]
@@ -149,12 +149,12 @@ let%expect_test "Rep with even-parity tail" =
   oracle
     [| capture "z" (rep (lit 'a') 0 2) ^. plus (lit 'a' ^. lit 'a') |]
     "aaaaa";
-  [%expect {| ERROR "aaaaa" -> ref=rule 0, len 5, [z="a"] dfa=rule 0, len 5, [z="aa"] |}]
+  [%expect {| "aaaaa" -> rule 0, len 5, [z="a"] |}]
 
 let%expect_test "star/capture ambiguity (greedy spec)" =
   (* Greedy: the star takes as much as it can, the capture gets the rest. *)
   oracle [| star (lit 'a') ^. capture "x" (plus (lit 'a')) |] "aaa";
-  [%expect {| ERROR "aaa" -> ref=rule 0, len 3, [x="a"] dfa=rule 0, len 3, [x=""] |}]
+  [%expect {| "aaa" -> rule 0, len 3, [x="a"] |}]
 
 (* ================================================================== *)
 (* BUG: loop preceding a capture (single-register-vector miscompute)   *)
@@ -165,14 +165,14 @@ let%expect_test "BUG: star before variable-length capture" =
      epsilon closure refires the capture's start tag on every star
      iteration, so the recorded start drifts to the last 'a'. *)
   oracle [| star (lit 'a') ^. capture "x" (lit 'a' ^. plus (lit 'b')) |] "aabb";
-  [%expect {| ERROR "aabb" -> ref=rule 0, len 4, [x="abb"] dfa=rule 0, len 4, [x="bb"] |}]
+  [%expect {| "aabb" -> rule 0, len 4, [x="abb"] |}]
 
 let%expect_test "BUG: capture start refires past capture entry" =
   (* The start tag refires even on characters consumed INSIDE the capture
      (the star path stays alive in the DFA state), so x can come out as a
      value Plus 'a' cannot even match. *)
   oracle [| star (lit 'a') ^. capture "x" (plus (lit 'a')) ^. lit 'b' |] "aab";
-  [%expect {| ERROR "aab" -> ref=rule 0, len 3, [x="a"] dfa=rule 0, len 3, [x=""] |}]
+  [%expect {| "aab" -> rule 0, len 3, [x="a"] |}]
 
 let%expect_test "BUG: star before capture with overlapping alt" =
   oracle
@@ -195,37 +195,8 @@ let%expect_test "BUG: multiple stars before single-char capture" =
 
 let%expect_test "qcheck: single rule" =
   qcheck (G.map2 (fun r s -> ([| r |], s)) gen_ir gen_input);
-  [%expect {|
-      rule0: ((Plus ['b'-'d'] as x), ['a'-'d'], Star ['c'-'d'])
-    ERROR "bdc" -> ref=rule 0, len 3, [x="bd"] dfa=rule 0, len 3, [x="bdc"]
-      rule0: ((Rep('b', 1..3) as x), (Plus 'b' as y))
-    ERROR "bbac" -> ref=rule 0, len 2, [x="b", y="b"] dfa=rule 0, len 2, [x="bb", y=""]
-      rule0: ((Star Star 'c' as x), Plus ['a'-'c'])
-    ERROR "ccd" -> ref=rule 0, len 2, [x="c"] dfa=rule 0, len 2, [x="cc"]
-      rule0: ((Plus ['b'-'d'] as x), 'b', Star 'c')
-    ERROR "bba" -> ref=rule 0, len 2, [x="b"] dfa=rule 0, len 2, [x="bb"]
-      rule0: (((Rep(['c'-'d'], 0..1), Plus 'a') as x), ((['a', 'd'] | ('a', 'd')) as y))
-    ERROR "aabc" -> ref=rule 0, len 2, [x="a", y="a"] dfa=rule 0, len 2, [x="aa", y=""]
-    5/2000 cases failed (printed at most 5)
-    |}]
+  [%expect {| |}]
 
 let%expect_test "qcheck: two rules" =
   qcheck ~count:1000 (G.map3 (fun a b s -> ([| a; b |], s)) gen_ir gen_ir gen_input);
-  [%expect {|
-      rule0: ((Star Plus ['a'-'c'] as x), Plus Rep(['b'-'c'], 1..3))
-      rule1: (('b' as x), 'a', ((Rep('a', 0..2), 'd') as z))
-    ERROR "c" -> ref=rule 0, len 1, [x=""] dfa=rule 0, len 1, [x="c"]
-      rule0: ('a' as x)
-      rule1: (((Star ['c'-'d'], ['a'-'c']) as x), (['a', 'd'] | Rep(['b'-'d'], 1..2)), Star ['c'-'d'], Star (['a'-'d'], 'a'))
-    ERROR "ccb" -> ref=rule 1, len 3, [x="cc"] dfa=rule 1, len 3, [x="ccb"]
-      rule0: (Star 'd', (['a'-'d'] as y), ['a'-'d'], ((Star 'a' | 'b') as w))
-      rule1: (['a'-'c'], ('a' as y))
-    ERROR "ddd" -> ref=rule 0, len 3, [w="", y="d"] dfa=rule 0, len 3, [w=<5..3>, y=<3..4>]
-      rule0: ((Star ['a'-'c'] as x), Plus ['a'-'b'], ['a'-'d'])
-      rule1: (((('d', ['a'-'d']) | (['a'-'b'], ['b'-'d'])) as x), Star 'd', ('d' as z))
-    ERROR "bd" -> ref=rule 0, len 2, [x=""] dfa=rule 0, len 2, [x="b"]
-      rule0: (((Star ['a'-'d'] | Rep(['c'-'d'], 0..2)) as x), 'a', (Plus 'b' as z))
-      rule1: ((Plus ['a'-'d'] as x), Plus ['a'-'d'], ('d' as z))
-    ERROR "ccd" -> ref=rule 1, len 3, [x="c", z="d"] dfa=rule 1, len 3, [x="ccd", z="d"]
-    6/1000 cases failed (printed at most 5)
-    |}]
+  [%expect {| |}]

--- a/test/oracle/test_oracle.ml
+++ b/test/oracle/test_oracle.ml
@@ -49,7 +49,8 @@ let%expect_test "multi-rule" =
       capture "x" (plus (cls 'a' 'c'));
     |]
     "abc";
-  [%expect {|
+  [%expect
+    {|
     "dbbe" -> rule 0, len 4, [x="bb"]
     "abc" -> rule 1, len 3, [x="abc"]
     |}]
@@ -69,7 +70,8 @@ let%expect_test "backtrack restores tags" =
 let%expect_test "bounded repetition" =
   oracle [| rep (lit 'a') 2 4 ^. capture "x" (plus (lit 'b')) |] "aaabbb";
   oracle [| rep (lit 'a') 2 4 ^. capture "x" (plus (lit 'b')) |] "abbb";
-  [%expect {|
+  [%expect
+    {|
     "aaabbb" -> rule 0, len 6, [x="bbb"]
     "abbb" -> no match
     |}]
@@ -79,7 +81,8 @@ let%expect_test "complement, subtraction, intersection" =
   oracle [| lit 'd' ^. capture "x" (compl (cls 'a' 'c')) ^. lit 'd' |] "dad";
   oracle [| capture "x" (plus (sub (cls 'a' 'e') (cls 'c' 'e'))) |] "abcde";
   oracle [| capture "x" (plus (inter (cls 'a' 'd') (cls 'c' 'f'))) |] "cdabe";
-  [%expect {|
+  [%expect
+    {|
     "dxd" -> rule 0, len 3, [x="x"]
     "dad" -> no match
     "abcde" -> rule 0, len 2, [x="ab"]
@@ -90,7 +93,8 @@ let%expect_test "Rep(0,1) capture" =
   oracle [| capture "z" (opt (cls 'a' 'c')) ^. star (lit 'b') |] "b";
   oracle [| capture "z" (opt (cls 'a' 'c')) ^. star (lit 'b') |] "ab";
   oracle [| capture "z" (opt (cls 'a' 'c')) ^. star (lit 'b') |] "bb";
-  [%expect {|
+  [%expect
+    {|
     "b" -> rule 0, len 1, [z="b"]
     "ab" -> rule 0, len 2, [z="a"]
     "bb" -> rule 0, len 2, [z="b"]
@@ -104,7 +108,8 @@ let%expect_test "or-pattern with discriminator" =
   oracle [| alt (capture "x" (lit 'a')) (capture "x" (lit 'b')) |] "a";
   oracle [| alt (capture "x" (lit 'a')) (capture "x" (lit 'b')) |] "b";
   oracle [| alt (capture "x" (lit 'a')) (capture "x" (lit 'b')) |] "c";
-  [%expect {|
+  [%expect
+    {|
     "a" -> rule 0, len 1, [x="a"]
     "b" -> rule 0, len 1, [x="b"]
     "c" -> no match
@@ -120,7 +125,8 @@ let%expect_test "or-pattern with variable-length branches" =
   in
   oracle (rules ()) "aaa";
   oracle (rules ()) "bccc";
-  [%expect {|
+  [%expect
+    {|
     "aaa" -> rule 0, len 3, [x="aaa"]
     "bccc" -> rule 0, len 4, [x="bccc"]
     |}]
@@ -136,7 +142,8 @@ let%expect_test "Rep greedy disambiguation" =
   oracle [| capture "z" (rep (cls 'a' 'c') 0 2) ^. plus (lit 'a') |] "aa";
   oracle [| capture "z" (rep (cls 'a' 'c') 0 2) ^. lit 'a' |] "aa";
   oracle [| capture "z" (rep (cls 'a' 'c') 0 2) ^. lit 'a' |] "aaa";
-  [%expect {|
+  [%expect
+    {|
     "aaa" -> rule 0, len 3, [z="aa"]
     "aa" -> rule 0, len 2, [z="a"]
     "aa" -> rule 0, len 2, [z="a"]
@@ -184,9 +191,7 @@ let%expect_test "BUG: star before capture with overlapping alt" =
   [%expect {| "aba" -> rule 0, len 3, [y="ba"] |}]
 
 let%expect_test "BUG: multiple stars before single-char capture" =
-  oracle
-    [| star (lit 'a') ^. capture "y" (lit 'b') ^. star (lit 'b') |]
-    "bb";
+  oracle [| star (lit 'a') ^. capture "y" (lit 'b') ^. star (lit 'b') |] "bb";
   [%expect {| "bb" -> rule 0, len 2, [y="b"] |}]
 
 (* ================================================================== *)
@@ -198,5 +203,6 @@ let%expect_test "qcheck: single rule" =
   [%expect {| |}]
 
 let%expect_test "qcheck: two rules" =
-  qcheck ~count:1000 (G.map3 (fun a b s -> ([| a; b |], s)) gen_ir gen_ir gen_input);
+  qcheck ~count:1000
+    (G.map3 (fun a b s -> ([| a; b |], s)) gen_ir gen_ir gen_input);
   [%expect {| |}]

--- a/test/oracle/test_oracle.ml
+++ b/test/oracle/test_oracle.ml
@@ -1,0 +1,231 @@
+(* The package sedlex is released under the terms of an MIT-like license. *)
+(* See the attached LICENSE file.                                         *)
+(* Copyright 2026, Hugo Heuzard                                           *)
+
+(* Oracle tests: the brute-force reference matcher vs the compiled DFA.
+   Lines prefixed with ERROR mark disagreements — i.e. compiler bugs.
+   The expect blocks record the CURRENT behavior; ERROR lines below are
+   the known capture-position bug (single register vector per NFA node)
+   and are expected to disappear with the TDFA rewrite. *)
+
+open Oracle
+
+(* ================================================================== *)
+(* Hand-written: basic capture shapes                                  *)
+(* ================================================================== *)
+
+let%expect_test "simple capture" =
+  oracle [| lit 'a' ^. capture "x" (plus (lit 'b')) ^. lit 'c' |] "abbc";
+  [%expect {| "abbc" -> rule 0, len 4, [x="bb"] |}]
+
+let%expect_test "whole-match capture" =
+  oracle [| capture "x" (plus (cls 'a' 'z')) |] "hello";
+  [%expect {| "hello" -> rule 0, len 5, [x="hello"] |}]
+
+let%expect_test "two captures in sequence" =
+  oracle
+    [| capture "x" (plus (lit 'a')) ^. capture "y" (plus (lit 'b')) |]
+    "aaabb";
+  [%expect {| "aaabb" -> rule 0, len 5, [x="aaa", y="bb"] |}]
+
+let%expect_test "variable-length capture" =
+  oracle [| lit 'd' ^. capture "c" (star (cls 'a' 'c')) ^. lit 'd' |] "dabcd";
+  [%expect {| "dabcd" -> rule 0, len 5, [c="abc"] |}]
+
+let%expect_test "no match" =
+  oracle [| lit 'a' ^. capture "x" (plus (lit 'b')) ^. lit 'c' |] "xyz";
+  [%expect {| "xyz" -> no match |}]
+
+let%expect_test "multi-rule" =
+  oracle
+    [|
+      lit 'd' ^. capture "x" (plus (lit 'b')) ^. lit 'e';
+      capture "x" (plus (cls 'a' 'c'));
+    |]
+    "dbbe";
+  oracle
+    [|
+      lit 'd' ^. capture "x" (plus (lit 'b')) ^. lit 'e';
+      capture "x" (plus (cls 'a' 'c'));
+    |]
+    "abc";
+  [%expect {|
+    "dbbe" -> rule 0, len 4, [x="bb"]
+    "abc" -> rule 1, len 3, [x="abc"]
+    |}]
+
+let%expect_test "backtrack restores tags" =
+  (* Rule 0 needs a trailing 'c'; on "aaabb" the DFA overruns into rule 0
+     territory, fails, and must backtrack to rule 1's accepting state with
+     rule 1's memory snapshot. *)
+  oracle
+    [|
+      capture "x" (plus (lit 'a')) ^. plus (lit 'b') ^. lit 'c';
+      capture "x" (plus (lit 'a')) ^. plus (lit 'b');
+    |]
+    "aaabb";
+  [%expect {| "aaabb" -> rule 1, len 5, [x="aaa"] |}]
+
+let%expect_test "bounded repetition" =
+  oracle [| rep (lit 'a') 2 4 ^. capture "x" (plus (lit 'b')) |] "aaabbb";
+  oracle [| rep (lit 'a') 2 4 ^. capture "x" (plus (lit 'b')) |] "abbb";
+  [%expect {|
+    "aaabbb" -> rule 0, len 6, [x="bbb"]
+    "abbb" -> no match
+    |}]
+
+let%expect_test "complement, subtraction, intersection" =
+  oracle [| lit 'd' ^. capture "x" (compl (cls 'a' 'c')) ^. lit 'd' |] "dxd";
+  oracle [| lit 'd' ^. capture "x" (compl (cls 'a' 'c')) ^. lit 'd' |] "dad";
+  oracle [| capture "x" (plus (sub (cls 'a' 'e') (cls 'c' 'e'))) |] "abcde";
+  oracle [| capture "x" (plus (inter (cls 'a' 'd') (cls 'c' 'f'))) |] "cdabe";
+  [%expect {|
+    "dxd" -> rule 0, len 3, [x="x"]
+    "dad" -> no match
+    "abcde" -> rule 0, len 2, [x="ab"]
+    "cdabe" -> rule 0, len 2, [x="cd"]
+    |}]
+
+let%expect_test "Rep(0,1) capture" =
+  oracle [| capture "z" (opt (cls 'a' 'c')) ^. star (lit 'b') |] "b";
+  oracle [| capture "z" (opt (cls 'a' 'c')) ^. star (lit 'b') |] "ab";
+  oracle [| capture "z" (opt (cls 'a' 'c')) ^. star (lit 'b') |] "bb";
+  [%expect {|
+    "b" -> rule 0, len 1, [z="b"]
+    "ab" -> rule 0, len 2, [z="a"]
+    "bb" -> rule 0, len 2, [z="b"]
+    |}]
+
+(* ================================================================== *)
+(* Or-patterns and discriminators                                      *)
+(* ================================================================== *)
+
+let%expect_test "or-pattern with discriminator" =
+  oracle [| alt (capture "x" (lit 'a')) (capture "x" (lit 'b')) |] "a";
+  oracle [| alt (capture "x" (lit 'a')) (capture "x" (lit 'b')) |] "b";
+  oracle [| alt (capture "x" (lit 'a')) (capture "x" (lit 'b')) |] "c";
+  [%expect {|
+    "a" -> rule 0, len 1, [x="a"]
+    "b" -> rule 0, len 1, [x="b"]
+    "c" -> no match
+    |}]
+
+let%expect_test "or-pattern with variable-length branches" =
+  let rules () =
+    [|
+      alt
+        (capture "x" (plus (lit 'a')))
+        (capture "x" (seq (lit 'b') (plus (lit 'c'))));
+    |]
+  in
+  oracle (rules ()) "aaa";
+  oracle (rules ()) "bccc";
+  [%expect {|
+    "aaa" -> rule 0, len 3, [x="aaa"]
+    "bccc" -> rule 0, len 4, [x="bccc"]
+    |}]
+
+(* ================================================================== *)
+(* Greedy disambiguation                                               *)
+(* ================================================================== *)
+
+let%expect_test "Rep greedy disambiguation" =
+  (* Bounded repetition should greedily take as many iterations as the
+     overall longest match allows. *)
+  oracle [| capture "z" (rep (cls 'a' 'c') 0 2) ^. plus (lit 'a') |] "aaa";
+  oracle [| capture "z" (rep (cls 'a' 'c') 0 2) ^. plus (lit 'a') |] "aa";
+  oracle [| capture "z" (rep (cls 'a' 'c') 0 2) ^. lit 'a' |] "aa";
+  oracle [| capture "z" (rep (cls 'a' 'c') 0 2) ^. lit 'a' |] "aaa";
+  [%expect {|
+    "aaa" -> rule 0, len 3, [z="aa"]
+    ERROR "aa" -> ref=rule 0, len 2, [z="a"] dfa=rule 0, len 2, [z="aa"]
+    "aa" -> rule 0, len 2, [z="a"]
+    "aaa" -> rule 0, len 3, [z="aa"]
+    |}]
+
+let%expect_test "Rep with even-parity tail" =
+  (* plus(seq('a','a')) needs an even number of trailing chars: for "aaaaa"
+     z=1 is the only repetition count that lets the tail match. *)
+  oracle
+    [| capture "z" (rep (lit 'a') 0 2) ^. plus (lit 'a' ^. lit 'a') |]
+    "aaaaa";
+  [%expect {| ERROR "aaaaa" -> ref=rule 0, len 5, [z="a"] dfa=rule 0, len 5, [z="aa"] |}]
+
+let%expect_test "star/capture ambiguity (greedy spec)" =
+  (* Greedy: the star takes as much as it can, the capture gets the rest. *)
+  oracle [| star (lit 'a') ^. capture "x" (plus (lit 'a')) |] "aaa";
+  [%expect {| ERROR "aaa" -> ref=rule 0, len 3, [x="a"] dfa=rule 0, len 3, [x=""] |}]
+
+(* ================================================================== *)
+(* BUG: loop preceding a capture (single-register-vector miscompute)   *)
+(* ================================================================== *)
+
+let%expect_test "BUG: star before variable-length capture" =
+  (* Unambiguous: the only complete parse is star="a", x="abb". The DFA's
+     epsilon closure refires the capture's start tag on every star
+     iteration, so the recorded start drifts to the last 'a'. *)
+  oracle [| star (lit 'a') ^. capture "x" (lit 'a' ^. plus (lit 'b')) |] "aabb";
+  [%expect {| ERROR "aabb" -> ref=rule 0, len 4, [x="abb"] dfa=rule 0, len 4, [x="bb"] |}]
+
+let%expect_test "BUG: capture start refires past capture entry" =
+  (* The start tag refires even on characters consumed INSIDE the capture
+     (the star path stays alive in the DFA state), so x can come out as a
+     value Plus 'a' cannot even match. *)
+  oracle [| star (lit 'a') ^. capture "x" (plus (lit 'a')) ^. lit 'b' |] "aab";
+  [%expect {| ERROR "aab" -> ref=rule 0, len 3, [x="a"] dfa=rule 0, len 3, [x=""] |}]
+
+let%expect_test "BUG: star before capture with overlapping alt" =
+  oracle
+    [|
+      star (lit 'a')
+      ^. capture "y" (alt (lit 'a' ^. cls 'a' 'c') (star (cls 'a' 'c')));
+    |]
+    "aba";
+  [%expect {| "aba" -> rule 0, len 3, [y="ba"] |}]
+
+let%expect_test "BUG: multiple stars before single-char capture" =
+  oracle
+    [| star (lit 'a') ^. capture "y" (lit 'b') ^. star (lit 'b') |]
+    "bb";
+  [%expect {| "bb" -> rule 0, len 2, [y="b"] |}]
+
+(* ================================================================== *)
+(* Random sweeps (deterministic seed)                                  *)
+(* ================================================================== *)
+
+let%expect_test "qcheck: single rule" =
+  qcheck (G.map2 (fun r s -> ([| r |], s)) gen_ir gen_input);
+  [%expect {|
+      rule0: ((Plus ['b'-'d'] as x), ['a'-'d'], Star ['c'-'d'])
+    ERROR "bdc" -> ref=rule 0, len 3, [x="bd"] dfa=rule 0, len 3, [x="bdc"]
+      rule0: ((Rep('b', 1..3) as x), (Plus 'b' as y))
+    ERROR "bbac" -> ref=rule 0, len 2, [x="b", y="b"] dfa=rule 0, len 2, [x="bb", y=""]
+      rule0: ((Star Star 'c' as x), Plus ['a'-'c'])
+    ERROR "ccd" -> ref=rule 0, len 2, [x="c"] dfa=rule 0, len 2, [x="cc"]
+      rule0: ((Plus ['b'-'d'] as x), 'b', Star 'c')
+    ERROR "bba" -> ref=rule 0, len 2, [x="b"] dfa=rule 0, len 2, [x="bb"]
+      rule0: (((Rep(['c'-'d'], 0..1), Plus 'a') as x), ((['a', 'd'] | ('a', 'd')) as y))
+    ERROR "aabc" -> ref=rule 0, len 2, [x="a", y="a"] dfa=rule 0, len 2, [x="aa", y=""]
+    5/2000 cases failed (printed at most 5)
+    |}]
+
+let%expect_test "qcheck: two rules" =
+  qcheck ~count:1000 (G.map3 (fun a b s -> ([| a; b |], s)) gen_ir gen_ir gen_input);
+  [%expect {|
+      rule0: ((Star Plus ['a'-'c'] as x), Plus Rep(['b'-'c'], 1..3))
+      rule1: (('b' as x), 'a', ((Rep('a', 0..2), 'd') as z))
+    ERROR "c" -> ref=rule 0, len 1, [x=""] dfa=rule 0, len 1, [x="c"]
+      rule0: ('a' as x)
+      rule1: (((Star ['c'-'d'], ['a'-'c']) as x), (['a', 'd'] | Rep(['b'-'d'], 1..2)), Star ['c'-'d'], Star (['a'-'d'], 'a'))
+    ERROR "ccb" -> ref=rule 1, len 3, [x="cc"] dfa=rule 1, len 3, [x="ccb"]
+      rule0: (Star 'd', (['a'-'d'] as y), ['a'-'d'], ((Star 'a' | 'b') as w))
+      rule1: (['a'-'c'], ('a' as y))
+    ERROR "ddd" -> ref=rule 0, len 3, [w="", y="d"] dfa=rule 0, len 3, [w=<5..3>, y=<3..4>]
+      rule0: ((Star ['a'-'c'] as x), Plus ['a'-'b'], ['a'-'d'])
+      rule1: (((('d', ['a'-'d']) | (['a'-'b'], ['b'-'d'])) as x), Star 'd', ('d' as z))
+    ERROR "bd" -> ref=rule 0, len 2, [x=""] dfa=rule 0, len 2, [x="b"]
+      rule0: (((Star ['a'-'d'] | Rep(['c'-'d'], 0..2)) as x), 'a', (Plus 'b' as z))
+      rule1: ((Plus ['a'-'d'] as x), Plus ['a'-'d'], ('d' as z))
+    ERROR "ccd" -> ref=rule 1, len 3, [x="c", z="d"] dfa=rule 1, len 3, [x="ccd", z="d"]
+    6/1000 cases failed (printed at most 5)
+    |}]

--- a/test/oracle/test_oracle.ml
+++ b/test/oracle/test_oracle.ml
@@ -226,6 +226,22 @@ let%expect_test "control: capture before a real char (no eof)" =
   oracle [| capture "x" (lit 'a') ^. lit 'b' |] "ab";
   [%expect {| "ab" -> rule 0, len 2, [x="a"] |}]
 
+let%expect_test "eof/rule-priority tie" =
+  (* An earlier rule and a later eof-terminated rule match the same length; the
+     earlier rule must win despite eof's zero-width mark landing later. *)
+  let a = [| plus (alt (lit 'b') (lit 'c')); seq (star (cls 'a' 'c')) eof |] in
+  oracle a "cc";
+  oracle a "c";
+  (* mirror: the eof-terminated rule is now first, so it wins the tie *)
+  let b = [| seq (star (cls 'a' 'c')) eof; plus (alt (lit 'b') (lit 'c')) |] in
+  oracle b "cc";
+  [%expect
+    {|
+    "cc" -> rule 0, len 2
+    "c" -> rule 0, len 1
+    "cc" -> rule 0, len 2
+    |}]
+
 (* ================================================================== *)
 (* Random sweeps (deterministic seed)                                  *)
 (* ================================================================== *)
@@ -238,5 +254,5 @@ let%expect_test "qcheck: two rules" =
   qcheck ~count:1000
     (G.map3
        (fun a b s -> ([| a; b |], s))
-       (gen_ir ()) (gen_ir ()) gen_input);
+       (gen_ir ~eof:true ()) (gen_ir ~eof:true ()) gen_input);
   [%expect {| |}]

--- a/test/oracle/test_oracle.ml
+++ b/test/oracle/test_oracle.ml
@@ -195,14 +195,48 @@ let%expect_test "BUG: multiple stars before single-char capture" =
   [%expect {| "bb" -> rule 0, len 2, [y="b"] |}]
 
 (* ================================================================== *)
+(* eof captures (regression for the fixed_length eof-width bug)         *)
+(* ================================================================== *)
+
+let%expect_test "capture spanning eof" =
+  (* eof is zero-width: the End_minus offset must not retreat across it, so
+     the capture keeps the whole preceding lexeme. *)
+  oracle [| capture "x" (star any) ^. eof |] "abc";
+  oracle [| capture "x" (lit 'a') ^. eof |] "a";
+  oracle [| star any ^. capture "x" (opt (lit 'a')) ^. eof |] "b";
+  [%expect
+    {|
+    "abc" -> rule 0, len 3, [x="abc"]
+    "a" -> rule 0, len 1, [x="a"]
+    "b" -> rule 0, len 1, [x=""]
+    |}]
+
+let%expect_test "capture before char-or-eof alternation" =
+  (* '(a | eof)' is one cset of data-dependent width, so the capture before
+     it must be tag-based, not offset-based. *)
+  oracle [| capture "x" (lit 'x') ^. alt (lit 'a') eof |] "x";
+  oracle [| capture "x" (lit 'x') ^. alt (lit 'a') eof |] "xa";
+  [%expect
+    {|
+    "x" -> rule 0, len 1, [x="x"]
+    "xa" -> rule 0, len 2, [x="x"]
+    |}]
+
+let%expect_test "control: capture before a real char (no eof)" =
+  oracle [| capture "x" (lit 'a') ^. lit 'b' |] "ab";
+  [%expect {| "ab" -> rule 0, len 2, [x="a"] |}]
+
+(* ================================================================== *)
 (* Random sweeps (deterministic seed)                                  *)
 (* ================================================================== *)
 
 let%expect_test "qcheck: single rule" =
-  qcheck (G.map2 (fun r s -> ([| r |], s)) gen_ir gen_input);
+  qcheck (G.map2 (fun r s -> ([| r |], s)) (gen_ir ~eof:true ()) gen_input);
   [%expect {| |}]
 
 let%expect_test "qcheck: two rules" =
   qcheck ~count:1000
-    (G.map3 (fun a b s -> ([| a; b |], s)) gen_ir gen_ir gen_input);
+    (G.map3
+       (fun a b s -> ([| a; b |], s))
+       (gen_ir ()) (gen_ir ()) gen_input);
   [%expect {| |}]


### PR DESCRIPTION
## Summary

This series fixes incorrect submatch positions for `as` bindings and puts the capture machinery on a proper theoretical footing.

**The bug.** The previous determinization attached one flat tag list per transition. A `Star`/`Plus` loop whose epsilon closure contained a capture's start-tag node re-fired the position write on every iteration, clobbering the position recorded by the path already inside the capture — yielding wrong, empty, or garbage submatches (e.g. `Star 'a', (('a', Plus 'b') as x)`).

**The fix.** Determinization is now a proper Laurikari tagged-DFA construction, modeled on ocamllex's `lex/lexgen.ml`:

- A DFA state is an ordered list of configurations (NFA node, per-tag register map); order is priority. Epsilon closure is a DFS in `eps`-list order and the first path to a node wins, giving leftmost-greedy disambiguation among maximal-length matches.
- State lookup is modulo bijective register renaming. Hitting an existing state emits Set/Copy register moves as a **parallel move**; the PPX let-binds clobbered Copy sources, so no move ordering or temporary cells are needed (unlike ocamllex's interpreted C engine).
- A final rename pass collapses **conflict-free tags** (never two distinct registers in one DFA state) into their canonical cell and drops the resulting no-op copies. Most patterns end up with exactly one cell per logical tag; only genuinely conflicted shapes (e.g. a loop before an overlapping capture) pay for extra working registers.

**Verification.** A new oracle harness (`test/oracle/`) compares a brute-force leftmost-greedy reference matcher over `Ir.t` against a faithful interpreter of the compiled DFA (including mark/backtrack and final-ops semantics) on exhaustive small inputs plus deterministic seeded random sweeps. The codegen expect-tests now also include non-eliminable counterparts for every `as`-binding shape whose positions would otherwise be computed statically, so the generated tag operations are visible in the expected output.

## Commits

- `Add Cset.mem for code point membership testing`
- `Add oracle tests: reference matcher vs compiled tagged DFA`
- `Add Copy tag operation to runtime, PPX, and oracle interpreter`
- `Rewrite determinization as a proper Laurikari TDFA`
- `Compile register moves as parallel moves, dropping temp cells`
- `Write conflict-free tags directly to their canonical cell`
- `Simplify Seq lowering to two list folds`
- `Add non-eliminable counterparts for static as-binding tests`
- `Remove duplicate or-pattern as-binding test`

## Future work (tracked as Goal notes in test/codegen/test_gen.ml)

- Cross-rule cell sharing (non-interfering rules reusing cells)
- Dead tag elimination on shared prefixes
- Self-loop tag delay (`set_mem_prev` on exit instead of O(n) writes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)